### PR TITLE
Add signup/login pages and fix dashboard routes

### DIFF
--- a/src/api/auth/[...nextauth]/route.ts
+++ b/src/api/auth/[...nextauth]/route.ts
@@ -1,1 +1,0 @@
-export { GET, POST } from '../../../../auth';

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from '../../../../../auth';

--- a/src/app/candidate/availability/page.tsx
+++ b/src/app/candidate/availability/page.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { CandidateShell } from "../../components/layouts";
-import { Card, Button } from "../../components/ui";
+import { CandidateShell } from "../../../components/layouts";
+import { Card, Button } from "../../../components/ui";
 import React from 'react';
 
 function Grid(){

--- a/src/app/candidate/browse/page.tsx
+++ b/src/app/candidate/browse/page.tsx
@@ -1,5 +1,5 @@
-import { CandidateShell } from "../../components/layouts";
-import { Card } from "../../components/ui";
+import { CandidateShell } from "../../../components/layouts";
+import { Card } from "../../../components/ui";
 
 export default function Browse(){
   return (

--- a/src/app/candidate/dashboard/page.tsx
+++ b/src/app/candidate/dashboard/page.tsx
@@ -1,5 +1,5 @@
-import { CandidateShell } from "../../components/layouts";
-import { Card, Button } from "../../components/ui";
+import { CandidateShell } from "../../../components/layouts";
+import { Card, Button } from "../../../components/ui";
 
 const upcoming = [
   {name:'Ethan Harper', title:'Senior Consultant at Global Consulting Firm'},

--- a/src/app/candidate/detail/[id]/page.tsx
+++ b/src/app/candidate/detail/[id]/page.tsx
@@ -1,5 +1,5 @@
-import { CandidateShell } from "../../../components/layouts";
-import { Button, Card, Badge } from "../../../components/ui";
+import { CandidateShell } from "../../../../components/layouts";
+import { Button, Card, Badge } from "../../../../components/ui";
 
 export default function Detail(){
   return (

--- a/src/app/candidate/history/page.tsx
+++ b/src/app/candidate/history/page.tsx
@@ -1,5 +1,5 @@
-import { CandidateShell } from "../../components/layouts";
-import { Card } from "../../components/ui";
+import { CandidateShell } from "../../../components/layouts";
+import { Card } from "../../../components/ui";
 
 export default function History(){
   const rows = [

--- a/src/app/candidate/settings/page.tsx
+++ b/src/app/candidate/settings/page.tsx
@@ -1,5 +1,5 @@
-import { CandidateShell } from "../../components/layouts";
-import { Card, Button, Input } from "../../components/ui";
+import { CandidateShell } from "../../../components/layouts";
+import { Card, Button, Input } from "../../../components/ui";
 
 export default function CandidateSettings(){
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,8 +26,8 @@ export default function RootLayout({
               </nav>
             </div>
             <div className="row" style={{ gap: 8 }}>
-              <Link href="/api/auth/signin" className="btn">Log In</Link>
-              <Link href="/candidate/dashboard" className="btn btn-primary">Sign Up</Link>
+              <Link href="/signup" className="btn">Log In</Link>
+              <Link href="/signup" className="btn btn-primary">Sign Up</Link>
             </div>
           </div>
         </header>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { auth } from "../../../auth";
+import { PublicShell } from "../../components/layouts";
+import { Card, Input, Button } from "../../components/ui";
+
+export default async function LoginPage() {
+  const session = await auth();
+  if (session?.user) {
+    redirect(session.user.role === 'PROFESSIONAL' ? '/professional/dashboard' : '/candidate/dashboard');
+  }
+  return (
+    <PublicShell>
+      <Card style={{ maxWidth: 400, margin: '40px auto', padding: 24 }}>
+        <h1>Log In</h1>
+        <form className="col" style={{ gap: 12 }}>
+          <Input type="email" placeholder="Email" required />
+          <Input type="password" placeholder="Password" required />
+          <Button type="submit">Log In</Button>
+        </form>
+        <p style={{ marginTop: 8 }}>
+          Don't have an account? <Link href="/signup">Sign up</Link>
+        </p>
+      </Card>
+    </PublicShell>
+  );
+}

--- a/src/app/professional/dashboard/page.tsx
+++ b/src/app/professional/dashboard/page.tsx
@@ -1,5 +1,5 @@
-import { ProfessionalShell } from "../../components/layouts";
-import { Card, Button } from "../../components/ui";
+import { ProfessionalShell } from "../../../components/layouts";
+import { Card, Button } from "../../../components/ui";
 
 export default function ProDashboard(){
   return (

--- a/src/app/professional/earnings/page.tsx
+++ b/src/app/professional/earnings/page.tsx
@@ -1,5 +1,5 @@
-import { ProfessionalShell } from "../../components/layouts";
-import { Card } from "../../components/ui";
+import { ProfessionalShell } from "../../../components/layouts";
+import { Card } from "../../../components/ui";
 
 export default function Earnings(){
   return (

--- a/src/app/professional/feedback/page.tsx
+++ b/src/app/professional/feedback/page.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { ProfessionalShell } from "../../components/layouts";
-import { Card, Button, Input } from "../../components/ui";
+import { ProfessionalShell } from "../../../components/layouts";
+import { Card, Button, Input } from "../../../components/ui";
 import React from 'react';
 
 export default function SubmitFeedback(){

--- a/src/app/professional/requests/page.tsx
+++ b/src/app/professional/requests/page.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { ProfessionalShell } from "../../components/layouts";
-import { Card, Button } from "../../components/ui";
+import { ProfessionalShell } from "../../../components/layouts";
+import { Card, Button } from "../../../components/ui";
 import React from 'react';
 
 function SchedulingOverlay(){

--- a/src/app/professional/settings/page.tsx
+++ b/src/app/professional/settings/page.tsx
@@ -1,5 +1,5 @@
-import { ProfessionalShell } from "../../components/layouts";
-import { Card, Button, Input } from "../../components/ui";
+import { ProfessionalShell } from "../../../components/layouts";
+import { Card, Button, Input } from "../../../components/ui";
 
 export default function ProSettings(){
   return (

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { auth } from "../../../auth";
+import { PublicShell } from "../../components/layouts";
+import { Card, Input, Button } from "../../components/ui";
+
+export default async function SignUpPage() {
+  const session = await auth();
+  if (session?.user) {
+    redirect(session.user.role === 'PROFESSIONAL' ? '/professional/dashboard' : '/candidate/dashboard');
+  }
+  return (
+    <PublicShell>
+      <Card style={{ maxWidth: 400, margin: '40px auto', padding: 24 }}>
+        <h1>Sign Up</h1>
+        <form className="col" style={{ gap: 12 }}>
+          <Input type="email" placeholder="Email" required />
+          <Input type="password" placeholder="Password" required />
+          <Button type="submit">Create Account</Button>
+        </form>
+        <p style={{ marginTop: 8 }}>
+          Already have an account? <Link href="/login">Log in</Link>
+        </p>
+      </Card>
+    </PublicShell>
+  );
+}


### PR DESCRIPTION
## Summary
- add dedicated signup and login pages with redirect to dashboards when authenticated
- update header links to point to signup page
- move candidate and professional routes into the app router so dashboards resolve

## Testing
- `npm test` *(fails: Unknown reporter: basic)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a23f0d1c0c8325a8fc344c518f0b75