### PR TITLE
fix: improve google oauth setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ See `.env.example` for all required variables and flags. **Exactly these feature
 - `FEATURE_SUCCESS_FEE` (default: true)
 - `FEATURE_QC_LLM` (default: true)
 
+Additionally, OAuth requires these environment variables:
+
+- `AUTH_SECRET` and `NEXTAUTH_URL`
+- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`
+- `LINKEDIN_CLIENT_ID` / `LINKEDIN_CLIENT_SECRET`
+
+For Google sign‑in, ensure the Google Cloud Console lists `http://localhost:3000/api/auth/callback/google` (or your deploy URL) under **Authorized redirect URIs**.
+
 ---
 
 ## Migrations & Seeding

--- a/auth.ts
+++ b/auth.ts
@@ -28,9 +28,16 @@ export const { handlers: { GET, POST }, auth, signIn, signOut } = NextAuth({
       }
     }),
     Google({
-      clientId: process.env.GOOGLE_CLIENT_ID || '',
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
-      authorization: { params: { scope: 'openid email profile https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.events' } }
+      clientId: process.env.GOOGLE_CLIENT_ID as string,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET as string,
+      authorization: {
+        params: {
+          scope: 'openid email profile https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.events',
+          prompt: 'consent',
+          access_type: 'offline',
+          response_type: 'code'
+        }
+      }
     }),
     LinkedIn({
       clientId: process.env.LINKEDIN_CLIENT_ID || '',


### PR DESCRIPTION
## Summary
- configure Google provider with explicit consent, offline access and code response
- document required environment variables and redirect URL for OAuth

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a3452264948325b5991aee5669cc3f