### PR TITLE
feat: add role selection to sign up

### DIFF
--- a/src/api/auth/signup/route.ts
+++ b/src/api/auth/signup/route.ts
@@ -5,17 +5,21 @@ import { z } from 'zod';
 
 export async function POST(req: NextRequest) {
   const body = await req.json().catch(() => null);
-  const schema = z.object({ email: z.string().email(), password: z.string().min(6) });
+  const schema = z.object({
+    email: z.string().email(),
+    password: z.string().min(6),
+    role: z.enum(['CANDIDATE', 'PROFESSIONAL'])
+  });
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
     return NextResponse.json({ error: 'invalid_body' }, { status: 400 });
   }
-  const { email, password } = parsed.data;
+  const { email, password, role } = parsed.data;
   const existing = await prisma.user.findUnique({ where: { email } });
   if (existing) {
     return NextResponse.json({ error: 'email_in_use' }, { status: 400 });
   }
   const hashedPassword = await bcrypt.hash(password, 10);
-  await prisma.user.create({ data: { email, hashedPassword, role: 'CANDIDATE' } });
+  await prisma.user.create({ data: { email, hashedPassword, role } });
   return NextResponse.json({ ok: true });
 }

--- a/src/app/signup/SignUpForm.tsx
+++ b/src/app/signup/SignUpForm.tsx
@@ -1,11 +1,12 @@
 'use client';
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
-import { Input, Button } from '../../components/ui';
+import { Input, Button, Select } from '../../components/ui';
 
 export default function SignUpForm() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [role, setRole] = useState<'CANDIDATE' | 'PROFESSIONAL' | ''>('');
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -13,15 +14,16 @@ export default function SignUpForm() {
     const form = e.currentTarget;
     const email = (form.elements.namedItem('email') as HTMLInputElement).value;
     const password = (form.elements.namedItem('password') as HTMLInputElement).value;
+    const role = (form.elements.namedItem('role') as HTMLSelectElement).value as 'CANDIDATE' | 'PROFESSIONAL';
     setLoading(true);
     const res = await fetch('/api/auth/signup', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email, password })
+      body: JSON.stringify({ email, password, role })
     });
     setLoading(false);
     if (res.ok) {
-      await signIn('credentials', { email, password, callbackUrl: '/candidate/dashboard' });
+      await signIn('credentials', { email, password, callbackUrl: role === 'PROFESSIONAL' ? '/professional/dashboard' : '/candidate/dashboard' });
     } else {
       const data = await res.json().catch(() => null);
       setError(data?.error || 'Failed to sign up');
@@ -30,12 +32,22 @@ export default function SignUpForm() {
 
   return (
     <form onSubmit={handleSubmit} className="col" style={{ gap: 12 }}>
+      <Select
+        name="role"
+        value={role}
+        onChange={(e) => setRole(e.target.value as 'CANDIDATE' | 'PROFESSIONAL')}
+        required
+      >
+        <option value="" disabled>Select account type</option>
+        <option value="CANDIDATE">Candidate</option>
+        <option value="PROFESSIONAL">Professional</option>
+      </Select>
       <Input name="email" type="email" placeholder="Email" required />
       <Input name="password" type="password" placeholder="Password" required />
       {error && <p style={{ color: 'red' }}>{error}</p>}
       <Button type="submit" disabled={loading}>Create Account</Button>
-      <Button type="button" onClick={() => signIn('google')} variant="muted">Sign up with Google</Button>
-      <Button type="button" onClick={() => signIn('linkedin')} variant="muted">Sign up with LinkedIn</Button>
+      <Button type="button" onClick={() => signIn('google', { callbackUrl: role === 'PROFESSIONAL' ? '/professional/dashboard' : '/candidate/dashboard' })} variant="muted" disabled={!role}>Sign up with Google</Button>
+      <Button type="button" onClick={() => signIn('linkedin', { callbackUrl: role === 'PROFESSIONAL' ? '/professional/dashboard' : '/candidate/dashboard' })} variant="muted" disabled={!role}>Sign up with LinkedIn</Button>
     </form>
   );
 }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -14,6 +14,13 @@ export default async function SignUpPage() {
     <PublicShell>
       <Card style={{ maxWidth: 400, margin: '40px auto', padding: 24 }}>
         <h1>Sign Up</h1>
+        <p style={{ margin: '8px 0' }}>
+          Choose the type of account you'd like to create.
+        </p>
+        <ul style={{ marginBottom: 16 }}>
+          <li><strong>Professional</strong> &ndash; post jobs and manage applicants.</li>
+          <li><strong>Candidate</strong> &ndash; apply to jobs and track your applications.</li>
+        </ul>
         <SignUpForm />
         <p style={{ marginTop: 8 }}>
           Already have an account? <Link href="/login">Log in</Link>


### PR DESCRIPTION
## Summary
- prompt users to choose professional or candidate on signup with explanation of each role
- capture selected role and redirect to appropriate dashboard
- persist chosen role during account creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a73f185a388325930d5ed7fd64c0dc