### PR TITLE
Redirect root path to appropriate dashboard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,13 @@
 import { PublicShell } from "../components/layouts";
-import { Button, Card } from "../components/ui";
+import { Card } from "../components/ui";
+import { auth } from "../../auth";
+import { redirect } from "next/navigation";
 
-export default function Landing(){
+export default async function Landing(){
+  const session = await auth();
+  if(session?.user){
+    redirect(session.user.role === 'PROFESSIONAL' ? '/professional/dashboard' : '/candidate/dashboard');
+  }
   return (
     <PublicShell>
       <section className="hero">


### PR DESCRIPTION
## Summary
- redirect `/` to the user dashboard based on role when authenticated
- clean up unused import in landing page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7b2b33af483258bb5f1c4386aaef0