### PR TITLE
Redirect root path to dashboard for authenticated users

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,11 +21,13 @@ export default async function RootLayout({
           <div className="container row" style={{ justifyContent: "space-between" }}>
             <div className="row" style={{ gap: 12 }}>
               <img src="/brand/monet-wordmark.svg" alt="Monet" height={32} />
-              <nav className="nav">
-                <Link href="/#about">About Us</Link>
-                <Link href="/#how">How It Works</Link>
-                <Link href="/#contact">Contact</Link>
-              </nav>
+              {!session?.user && (
+                <nav className="nav">
+                  <Link href="/#about">About Us</Link>
+                  <Link href="/#how">How It Works</Link>
+                  <Link href="/#contact">Contact</Link>
+                </nav>
+              )}
             </div>
             <div className="row" style={{ gap: 8 }}>
               {session?.user ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,12 @@
 import { PublicShell } from "../components/layouts";
-import { Button, Card } from "../components/ui";
+import { Card } from "../components/ui";
+import { auth } from "../../auth";
+import { redirect } from "next/navigation";
 
-export default function Landing(){
+export default async function Landing(){
+  const session = await auth();
+  if(session?.user?.role === 'CANDIDATE') redirect('/candidate/dashboard');
+  if(session?.user?.role === 'PROFESSIONAL') redirect('/professional/dashboard');
   return (
     <PublicShell>
       <section className="hero">


### PR DESCRIPTION
## Summary
- Redirect logged-in users visiting `/` to their candidate or professional dashboards
- Hide landing page navigation links when a session exists to avoid buttons pointing to the root path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7b2b33af483258bb5f1c4386aaef0