### PR TITLE
Fix layout navigation reload by using Next.js Link

### DIFF
--- a/src/components/layouts.tsx
+++ b/src/components/layouts.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React from 'react';
+import Link from 'next/link';
 
 export function PublicShell({children}:{children:React.ReactNode}){
   return <div className="container">{children}</div>;
@@ -62,7 +63,11 @@ export function AdminShell({children}:{children:React.ReactNode}){
 function Nav({items}:{items:{href:string, label:string}[]}){
   return (
     <nav className="col">
-      {items.map(i=> <a key={i.href} href={i.href} className="nav-link">{i.label}</a>)}
+      {items.map(i => (
+        <Link key={i.href} href={i.href} className="nav-link">
+          {i.label}
+        </Link>
+      ))}
       <style jsx>{`
         .nav-link{ padding:10px 12px; border-radius:10px; display:block; color:var(--text-muted)}
         .nav-link:hover{ background:var(--muted); color:var(--text)}


### PR DESCRIPTION
## Summary
- use Next.js `Link` in layout navigation to prevent full page reloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7b2f78bdc83259d86d2ca52440dc8