### PR TITLE
Redesign candidate dashboard with responsive layout

### DIFF
--- a/src/app/candidate/dashboard/page.tsx
+++ b/src/app/candidate/dashboard/page.tsx
@@ -1,64 +1,108 @@
+import Link from "next/link";
 import { CandidateShell } from "../../../components/layouts";
-import { Card, Button } from "../../../components/ui";
+import { Card, Button, Badge, DataTable } from "../../../components/ui";
 
 const upcoming = [
-  {name:'Ethan Harper', title:'Senior Consultant at Global Consulting Firm'},
-  {name:'Olivia Bennett', title:'Finance Manager at Tech Innovators Inc.'},
-  {name:'Noah Carter', title:'Independent Strategy Advisor'},
-  {name:'Ava Morgan', title:'Principal at Investment Group'},
-  {name:'Liam Foster', title:'Consulting Partner at Top Tier Firm'},
+  { name: "Ethan Harper", title: "Senior Consultant at Global Consulting Firm" },
+  { name: "Olivia Bennett", title: "Finance Manager at Tech Innovators Inc." },
+  { name: "Noah Carter", title: "Independent Strategy Advisor" },
+  { name: "Ava Morgan", title: "Principal at Investment Group" },
+  { name: "Liam Foster", title: "Consulting Partner at Top Tier Firm" },
 ];
+
+const filters = ["Industry", "Firm", "Experience Level", "Availability"];
 
 const results = [
-  {employer:'Global Consulting Firm', title:'Senior Consultant', experience:'5+ years', availability:'Weekdays'},
-  {employer:'Tech Innovators Inc.', title:'Finance Manager', experience:'8+ years', availability:'Weekends'},
-  {employer:'Independent', title:'Strategy Advisor', experience:'10+ years', availability:'Evenings'},
-  {employer:'Investment Group', title:'Principal', experience:'7+ years', availability:'Flexible'},
-  {employer:'Top Tier Firm', title:'Consulting Partner', experience:'12+ years', availability:'Weekdays'},
+  {
+    id: 1,
+    name: "Ethan Harper",
+    title: "Senior Consultant at Global Consulting Firm",
+    experience: "5+ years",
+    availability: "Weekdays",
+  },
+  {
+    id: 2,
+    name: "Olivia Bennett",
+    title: "Finance Manager at Tech Innovators Inc.",
+    experience: "8+ years",
+    availability: "Weekends",
+  },
+  {
+    id: 3,
+    name: "Noah Carter",
+    title: "Independent Strategy Advisor",
+    experience: "10+ years",
+    availability: "Evenings",
+  },
+  {
+    id: 4,
+    name: "Ava Morgan",
+    title: "Principal at Investment Group",
+    experience: "7+ years",
+    availability: "Flexible",
+  },
+  {
+    id: 5,
+    name: "Liam Foster",
+    title: "Consulting Partner at Top Tier Firm",
+    experience: "12+ years",
+    availability: "Weekdays",
+  },
 ];
 
-export default function CandidateDashboard(){
+export default function CandidateDashboard() {
   return (
     <CandidateShell>
-      <aside>
-        <Card style={{padding:12}}>
-          <h3>Upcoming Calls</h3>
-          <div className="col" style={{gap:8}}>
-            {upcoming.map(u=>(
-              <div key={u.name} className="row" style={{justifyContent:'space-between'}}>
-                <div className="col"><strong>{u.name}</strong><span style={{color:'var(--text-muted)'}}>{u.title}</span></div>
-                <Button>Join</Button>
-              </div>
+      <div className="row" style={{ alignItems: "flex-start", gap: 24 }}>
+        <aside style={{ width: 260 }}>
+          <Card className="col" style={{ padding: 16 }}>
+            <h3>Upcoming Calls</h3>
+            <div className="col" style={{ gap: 12 }}>
+              {upcoming.map((u) => (
+                <div
+                  key={u.name}
+                  className="row"
+                  style={{ justifyContent: "space-between" }}
+                >
+                  <div className="col" style={{ gap: 2 }}>
+                    <strong>{u.name}</strong>
+                    <span style={{ color: "var(--text-muted)" }}>{u.title}</span>
+                  </div>
+                  <Button>Join</Button>
+                </div>
+              ))}
+            </div>
+          </Card>
+        </aside>
+        <section className="col" style={{ gap: 16, flex: 1 }}>
+          <h2>Search Results</h2>
+          <p style={{ color: "var(--text-muted)" }}>
+            Showing results for your search criteria
+          </p>
+          <div className="row" style={{ gap: 8, flexWrap: "wrap" }}>
+            {filters.map((f) => (
+              <Badge key={f}>{f}</Badge>
             ))}
           </div>
-        </Card>
-      </aside>
-      <section className="col" style={{gap:16}}>
-        <h2>Search Results</h2>
-        <div className="row" style={{gap:8}}>
-          <div className="badge">Industry</div>
-          <div className="badge">Firm</div>
-          <div className="badge">Experience Level</div>
-          <div className="badge">Availability</div>
-        </div>
-        <Card style={{padding:0}}>
-          <table className="table">
-            <thead>
-              <tr><th>Title</th><th>Experience</th><th>Availability</th><th>Actions</th></tr>
-            </thead>
-            <tbody>
-              {results.map((r, i)=>(
-                <tr key={i}>
-                  <td>{r.title} at {r.employer}</td>
-                  <td>{r.experience}</td>
-                  <td>{r.availability}</td>
-                  <td><a href="/candidate/detail/1">View Profile</a></td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </Card>
-      </section>
+          <Card style={{ padding: 0 }}>
+            <DataTable
+              columns={[
+                { key: "name", label: "Name" },
+                { key: "title", label: "Title" },
+                { key: "experience", label: "Experience" },
+                { key: "availability", label: "Availability" },
+                { key: "action", label: "" },
+              ]}
+              rows={results.map((r) => ({
+                ...r,
+                action: (
+                  <Link href={`/candidate/detail/${r.id}`}>View Profile</Link>
+                ),
+              }))}
+            />
+          </Card>
+        </section>
+      </div>
     </CandidateShell>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "../../styles/global.css";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { headers } from "next/headers";
 import { auth, signOut } from "../../auth";
 
 export const metadata: Metadata = {
@@ -14,42 +15,46 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const session = await auth();
+  const path = headers().get("next-url") || "";
+  const showPublicHeader = !path.startsWith("/candidate");
   return (
     <html lang="en">
       <body>
-        <header style={{ borderBottom: "1px solid var(--border)", background: "#fff" }}>
-          <div className="container row" style={{ justifyContent: "space-between" }}>
-            <div className="row" style={{ gap: 12 }}>
-              <img src="/brand/monet-wordmark.svg" alt="Monet" height={32} />
-              <nav className="nav">
-                <Link href="/#about">About Us</Link>
-                <Link href="/#how">How It Works</Link>
-                <Link href="/#contact">Contact</Link>
-              </nav>
+        {showPublicHeader && (
+          <header style={{ borderBottom: "1px solid var(--border)", background: "#fff" }}>
+            <div className="container row" style={{ justifyContent: "space-between" }}>
+              <div className="row" style={{ gap: 12 }}>
+                <img src="/brand/monet-wordmark.svg" alt="Monet" height={32} />
+                <nav className="nav">
+                  <Link href="/#about">About Us</Link>
+                  <Link href="/#how">How It Works</Link>
+                  <Link href="/#contact">Contact</Link>
+                </nav>
+              </div>
+              <div className="row" style={{ gap: 8 }}>
+                {session?.user ? (
+                  <form
+                    action={async () => {
+                      "use server";
+                      await signOut();
+                    }}
+                  >
+                    <button className="btn btn-danger">Sign Out</button>
+                  </form>
+                ) : (
+                  <>
+                    <Link href="/login" className="btn">
+                      Log In
+                    </Link>
+                    <Link href="/signup" className="btn btn-primary">
+                      Sign Up
+                    </Link>
+                  </>
+                )}
+              </div>
             </div>
-            <div className="row" style={{ gap: 8 }}>
-              {session?.user ? (
-                <form
-                  action={async () => {
-                    "use server";
-                    await signOut();
-                  }}
-                >
-                  <button className="btn btn-danger">Sign Out</button>
-                </form>
-              ) : (
-                <>
-                  <Link href="/login" className="btn">
-                    Log In
-                  </Link>
-                  <Link href="/signup" className="btn btn-primary">
-                    Sign Up
-                  </Link>
-                </>
-              )}
-            </div>
-          </div>
-        </header>
+          </header>
+        )}
         <main>{children}</main>
       </body>
     </html>

--- a/src/components/layouts.tsx
+++ b/src/components/layouts.tsx
@@ -8,18 +8,26 @@ export function PublicShell({children}:{children:React.ReactNode}){
 
 export function CandidateShell({children}:{children:React.ReactNode}){
   return (
-    <div className="container" style={{display:'grid', gridTemplateColumns:'240px 1fr', gap:24}}>
-      <aside className="sidebar">
-        <Nav items={[
-          {href:'/candidate/dashboard', label:'Home'},
-          {href:'/candidate/browse', label:'Experts'},
-          {href:'/candidate/history', label:'History'},
-          {href:'/candidate/availability', label:'My Availability'},
-          {href:'/candidate/settings', label:'Settings'},
-        ]}/>
-      </aside>
-      <main>{children}</main>
-    </div>
+    <>
+      <header style={{borderBottom:'1px solid var(--border)', background:'#fff'}}>
+        <div className="container row" style={{justifyContent:'space-between'}}>
+          <div className="row" style={{gap:24, alignItems:'center'}}>
+            <Link href="/candidate/dashboard" style={{fontWeight:700}}>Connect</Link>
+            <nav className="nav">
+              <Link href="/candidate/dashboard">Home</Link>
+              <Link href="/candidate/browse">Experts</Link>
+              <Link href="#">Calendar</Link>
+              <Link href="/candidate/history">History</Link>
+              <Link href="/candidate/availability">My Availability</Link>
+            </nav>
+          </div>
+          <div className="row" style={{gap:8}}>
+            <Link href="/candidate/settings">Settings</Link>
+          </div>
+        </div>
+      </header>
+      <div className="container" style={{marginTop:24}}>{children}</div>
+    </>
   )
 }
 

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -27,14 +27,22 @@ export function Badge({children}:{children:React.ReactNode}){
   return <span className="badge">{children}</span>
 }
 
-export function DataTable<T>({columns, rows}:{columns:{key:keyof T, label:string}[], rows:T[]}){
+export function DataTable<T extends Record<string, React.ReactNode>>({columns, rows}:{columns:{key:keyof T, label:string}[], rows:T[]}){
   return (
     <table className="table">
-      <thead><tr>{columns.map(c=><th key={String(c.key)}>{c.label}</th>)}</tr></thead>
+      <thead>
+        <tr>
+          {columns.map(c => (
+            <th key={String(c.key)}>{c.label}</th>
+          ))}
+        </tr>
+      </thead>
       <tbody>
-        {rows.map((r, i)=>(
+        {rows.map((r, i) => (
           <tr key={i}>
-            {columns.map(c=>(<td key={String(c.key)}>{String(r[c.key])}</td>))}
+            {columns.map(c => (
+              <td key={String(c.key)}>{r[c.key]}</td>
+            ))}
           </tr>
         ))}
       </tbody>


### PR DESCRIPTION
## Summary
- Revamp candidate dashboard with upcoming calls sidebar, filter badges and dynamic results table
- Introduce top navigation header for candidate pages
- Enhance generic DataTable to support rich React node cells
- Hide public header on candidate routes in root layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7caa146bc8325a6a33e1b4ac9f8ab