### PR TITLE
Extract server sign-out action

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,0 +1,8 @@
+'use server';
+
+import { signOut } from '../auth';
+
+export async function signOutAction() {
+  await signOut();
+}
+

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState } from 'react';
-import { signIn } from 'next-auth/react';
+import { signIn, type SignInResponse } from 'next-auth/react';
 import { Input, Button } from '../../components/ui';
 
 export default function LoginForm() {
@@ -12,10 +12,11 @@ export default function LoginForm() {
     const form = e.currentTarget;
     const email = (form.elements.namedItem('email') as HTMLInputElement).value;
     const password = (form.elements.namedItem('password') as HTMLInputElement).value;
-    const res = await signIn('credentials', {
+    const res: SignInResponse | undefined = await signIn('credentials', {
       email,
       password,
       callbackUrl: '/candidate/dashboard',
+      redirect: false,
     });
     if (res?.error) {
       setError('Invalid credentials');

--- a/src/app/professional/earnings/page.tsx
+++ b/src/app/professional/earnings/page.tsx
@@ -1,5 +1,4 @@
 import { Card } from "../../../components/ui";
-import { Card } from "../../../components/ui";
 
 export default function Earnings(){
   return (

--- a/src/components/layouts.tsx
+++ b/src/components/layouts.tsx
@@ -1,6 +1,8 @@
+"use client";
+
 import React from 'react';
 import Link from 'next/link';
-import { signOut } from '../../auth';
+import { signOutAction } from '../actions';
 
 type ShellProps = { children: React.ReactNode; session?: any };
 
@@ -21,12 +23,7 @@ export function PublicShell({ children, session }: ShellProps) {
           </div>
           <div className="row" style={{ gap: 8 }}>
             {session?.user ? (
-              <form
-                action={async () => {
-                  'use server';
-                  await signOut();
-                }}
-              >
+              <form action={signOutAction}>
                 <button className="btn btn-danger">Sign Out</button>
               </form>
             ) : (
@@ -69,12 +66,7 @@ export function CandidateShell({ children }: ShellProps) {
 
           <div className="row" style={{ gap: 8 }}>
             <Link href="/candidate/settings">Settings</Link>
-            <form
-              action={async () => {
-                'use server';
-                await signOut();
-              }}
-            >
+            <form action={signOutAction}>
               <button className="btn btn-danger">Sign Out</button>
             </form>
           </div>
@@ -95,12 +87,7 @@ export function ProfessionalShell({ children }: ShellProps) {
           <Link href="/professional/dashboard" style={{ fontWeight: 700 }}>
             ExpertConnect
           </Link>
-          <form
-            action={async () => {
-              'use server';
-              await signOut();
-            }}
-          >
+          <form action={signOutAction}>
             <button className="btn btn-danger">Sign Out</button>
           </form>
         </div>


### PR DESCRIPTION
## Summary
- avoid inline server actions by moving sign-out logic to dedicated server action
- update layout shells to use server sign-out action
- remove duplicate Card import and mark layout as a client component
- refine login form sign-in handling to prevent type errors

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7d2af888c8325a1503c69e8f956e6