### PR TITLE
Fix shell selection with per-role layouts

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,7 @@
+import { auth } from "../../../auth";
+import { PublicShell } from "../../components/layouts";
+
+export default async function PublicLayout({ children }: { children: React.ReactNode }) {
+  const session = await auth();
+  return <PublicShell session={session}>{children}</PublicShell>;
+}

--- a/src/app/(public)/login/LoginForm.tsx
+++ b/src/app/(public)/login/LoginForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { signIn, type SignInResponse } from 'next-auth/react';
-import { Input, Button } from '../../components/ui';
+import { Input, Button } from '../../../components/ui';
 
 export default function LoginForm() {
   const [error, setError] = useState<string | null>(null);

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { auth } from "../../../auth";
-import { Card } from "../../components/ui";
+import { auth } from "../../../../auth";
+import { Card } from "../../../components/ui";
 import LoginForm from "./LoginForm";
 
 export default async function LoginPage() {

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,5 +1,5 @@
-import { Card } from "../components/ui";
-import { auth } from "../../auth";
+import { Card } from "../../components/ui";
+import { auth } from "../../../auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
 

--- a/src/app/(public)/signup/SignUpForm.tsx
+++ b/src/app/(public)/signup/SignUpForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { signIn } from 'next-auth/react';
-import { Input, Button, Select } from '../../components/ui';
+import { Input, Button, Select } from '../../../components/ui';
 
 export default function SignUpForm() {
   const [error, setError] = useState<string | null>(null);

--- a/src/app/(public)/signup/page.tsx
+++ b/src/app/(public)/signup/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
-import { auth } from "../../../auth";
-import { Card } from "../../components/ui";
+import { auth } from "../../../../auth";
+import { Card } from "../../../components/ui";
 import SignUpForm from "./SignUpForm";
 
 export default async function SignUpPage() {

--- a/src/app/admin/audit-logs/page.tsx
+++ b/src/app/admin/audit-logs/page.tsx
@@ -1,13 +1,10 @@
-import { AdminShell } from "../../components/layouts";
-import { Card } from "../../components/ui";
+import { Card } from "../../../components/ui";
 
 export default function Page(){
   return (
-    <AdminShell>
       <Card style={{ padding: 16 }}>
-        <h2>Feedback (QC)</h2>
+        <h2>Audit Logs</h2>
         <p>Minimalist data table with filters and CSV export.</p>
       </Card>
-    </AdminShell>
   );
 }

--- a/src/app/admin/bookings/page.tsx
+++ b/src/app/admin/bookings/page.tsx
@@ -1,13 +1,10 @@
-import { AdminShell } from "../../components/layouts";
-import { Card } from "../../components/ui";
+import { Card } from "../../../components/ui";
 
 export default function Page(){
   return (
-    <AdminShell>
       <Card style={{ padding: 16 }}>
-        <h2>Audit Logs</h2>
+        <h2>Bookings</h2>
         <p>Minimalist data table with filters and CSV export.</p>
       </Card>
-    </AdminShell>
   );
 }

--- a/src/app/admin/disputes/page.tsx
+++ b/src/app/admin/disputes/page.tsx
@@ -1,13 +1,10 @@
-import { AdminShell } from "../../components/layouts";
-import { Card } from "../../components/ui";
+import { Card } from "../../../components/ui";
 
 export default function Page(){
   return (
-    <AdminShell>
       <Card style={{ padding: 16 }}>
-        <h2>Payments</h2>
+        <h2>Disputes</h2>
         <p>Minimalist data table with filters and CSV export.</p>
       </Card>
-    </AdminShell>
   );
 }

--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -1,13 +1,10 @@
-import { AdminShell } from "../../components/layouts";
-import { Card } from "../../components/ui";
+import { Card } from "../../../components/ui";
 
 export default function Page(){
   return (
-    <AdminShell>
       <Card style={{ padding: 16 }}>
-        <h2>Payouts</h2>
+        <h2>Feedback (QC)</h2>
         <p>Minimalist data table with filters and CSV export.</p>
       </Card>
-    </AdminShell>
   );
 }

--- a/src/app/admin/invoices/page.tsx
+++ b/src/app/admin/invoices/page.tsx
@@ -1,13 +1,10 @@
-import { AdminShell } from "../../components/layouts";
-import { Card } from "../../components/ui";
+import { Card } from "../../../components/ui";
 
 export default function Page(){
   return (
-    <AdminShell>
       <Card style={{ padding: 16 }}>
-        <h2>Bookings</h2>
+        <h2>Invoices</h2>
         <p>Minimalist data table with filters and CSV export.</p>
       </Card>
-    </AdminShell>
   );
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,5 @@
+import { AdminShell } from "../../components/layouts";
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return <AdminShell>{children}</AdminShell>;
+}

--- a/src/app/admin/payments/page.tsx
+++ b/src/app/admin/payments/page.tsx
@@ -1,13 +1,10 @@
-import { AdminShell } from "../../components/layouts";
-import { Card } from "../../components/ui";
+import { Card } from "../../../components/ui";
 
 export default function Page(){
   return (
-    <AdminShell>
       <Card style={{ padding: 16 }}>
-        <h2>Invoices</h2>
+        <h2>Payments</h2>
         <p>Minimalist data table with filters and CSV export.</p>
       </Card>
-    </AdminShell>
   );
 }

--- a/src/app/admin/payouts/page.tsx
+++ b/src/app/admin/payouts/page.tsx
@@ -1,13 +1,10 @@
-import { AdminShell } from "../../components/layouts";
-import { Card } from "../../components/ui";
+import { Card } from "../../../components/ui";
 
 export default function Page(){
   return (
-    <AdminShell>
       <Card style={{ padding: 16 }}>
-        <h2>Users</h2>
+        <h2>Payouts</h2>
         <p>Minimalist data table with filters and CSV export.</p>
       </Card>
-    </AdminShell>
   );
 }

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,13 +1,10 @@
-import { AdminShell } from "../../components/layouts";
-import { Card } from "../../components/ui";
+import { Card } from "../../../components/ui";
 
 export default function Page(){
   return (
-    <AdminShell>
       <Card style={{ padding: 16 }}>
-        <h2>Disputes</h2>
+        <h2>Users</h2>
         <p>Minimalist data table with filters and CSV export.</p>
       </Card>
-    </AdminShell>
   );
 }

--- a/src/app/candidate/layout.tsx
+++ b/src/app/candidate/layout.tsx
@@ -1,0 +1,5 @@
+import { CandidateShell } from "../../components/layouts";
+
+export default function CandidateLayout({ children }: { children: React.ReactNode }) {
+  return <CandidateShell>{children}</CandidateShell>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,6 @@
 import "../../styles/global.css";
 import type { Metadata } from "next";
 
-import { headers } from "next/headers";
-import { auth } from "../../auth";
-import {
-  PublicShell,
-  CandidateShell,
-  ProfessionalShell,
-  AdminShell,
-} from "../components/layouts";
-
-
 export const metadata: Metadata = {
   title: "Monet",
   description: "Connect candidates with professionals for structured 30-minute calls.",
@@ -21,22 +11,9 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const session = await auth();
-  const path = headers().get("next-url") || "";
-
-  const Shell = path.startsWith("/candidate")
-    ? CandidateShell
-    : path.startsWith("/professional")
-    ? ProfessionalShell
-    : path.startsWith("/admin")
-    ? AdminShell
-    : PublicShell;
-
   return (
     <html lang="en">
-      <body>
-        <Shell session={session}>{children}</Shell>
-      </body>
+      <body>{children}</body>
     </html>
   );
 }

--- a/src/app/professional/layout.tsx
+++ b/src/app/professional/layout.tsx
@@ -1,0 +1,5 @@
+import { ProfessionalShell } from "../../components/layouts";
+
+export default function ProfessionalLayout({ children }: { children: React.ReactNode }) {
+  return <ProfessionalShell>{children}</ProfessionalShell>;
+}


### PR DESCRIPTION
## Summary
- remove path-based shell logic from root layout
- add dedicated layouts for public, candidate, professional and admin sections
- move admin and public pages under their route groups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7d75726a08325a2b0b5ac9286e973