### PR TITLE
feat: add dynamic filter dropdown

### DIFF
--- a/src/api/filterOptions.ts
+++ b/src/api/filterOptions.ts
@@ -1,0 +1,76 @@
+import { prisma } from "../../lib/db";
+import { PrismaClient } from "@prisma/client";
+
+export interface FilterOption {
+  model: keyof PrismaClient;
+  field: string;
+  /**
+   * Relation name from the base model to this model when building `where` clauses
+   */
+  relation?: string;
+  /**
+   * Whether the relation is to-many. If true, `some` will be used when generating
+   * nested Prisma where queries.
+   */
+  many?: boolean;
+  /**
+   * Optional transform applied to raw values when retrieving filter options
+   */
+  transform?: (values: any[]) => string[];
+}
+
+export type FilterConfig = Record<string, FilterOption>;
+
+export type ActiveFilters = Record<string, string[]>;
+
+/**
+ * Build a Prisma `where` object that applies all active filters simultaneously.
+ * This allows filtering across multiple models by specifying the relation path
+ * in the filter configuration.
+ */
+export function buildFilterWhere(
+  config: FilterConfig,
+  active: ActiveFilters
+) {
+  const where: any = {};
+  for (const [label, values] of Object.entries(active)) {
+    if (!values || values.length === 0) continue;
+    const cfg = config[label];
+    if (!cfg) continue;
+    if (!cfg.relation) {
+      // root-level field
+      where[cfg.field] = { in: values };
+    } else if (cfg.many) {
+      where[cfg.relation] = {
+        some: {
+          ...(where[cfg.relation]?.some || {}),
+          [cfg.field]: { in: values },
+        },
+      };
+    } else {
+      where[cfg.relation] = {
+        ...(where[cfg.relation] || {}),
+        [cfg.field]: { in: values },
+      };
+    }
+  }
+  return where;
+}
+
+export async function getFilterOptions(config: FilterConfig) {
+  const entries = Object.entries(config);
+  const results = await Promise.all(
+    entries.map(async ([label, { model, field, transform }]) => {
+      const data = await (prisma as any)[model].findMany({
+        distinct: [field],
+        select: { [field]: true },
+      });
+      const rawValues = data.map((d: any) => d[field]).filter(Boolean);
+      return [
+        label,
+        transform ? transform(rawValues) : (rawValues as string[]),
+      ] as [string, string[]];
+    })
+  );
+  return Object.fromEntries(results);
+}

--- a/src/components/FilterDropdown.tsx
+++ b/src/components/FilterDropdown.tsx
@@ -1,0 +1,81 @@
+'use client';
+import React, { useState } from 'react';
+import Dropdown from 'react-bootstrap/Dropdown';
+import Form from 'react-bootstrap/Form';
+
+// Custom toggle for Dropdown - required for proper positioning
+const CustomToggle = React.forwardRef<HTMLAnchorElement, any>(
+  ({ children, onClick }, ref) => (
+    <a
+      href=""
+      ref={ref}
+      onClick={(e) => {
+        e.preventDefault();
+        onClick?.(e);
+      }}
+    >
+      {children}
+      {' '}\u25bc
+    </a>
+  )
+);
+CustomToggle.displayName = 'CustomToggle';
+
+// Custom menu with a search box
+const CustomMenu = React.forwardRef<HTMLDivElement, any>(
+  ({ children, style, className, 'aria-labelledby': labeledBy }, ref) => {
+    const [value, setValue] = useState('');
+
+    return (
+      <div
+        ref={ref}
+        style={style}
+        className={className}
+        aria-labelledby={labeledBy}
+      >
+        <Form.Control
+          autoFocus
+          className="mx-3 my-2 w-auto"
+          placeholder="Type to filter..."
+          onChange={(e) => setValue(e.target.value)}
+          value={value}
+        />
+        <ul className="list-unstyled">
+          {React.Children.toArray(children).filter(
+            (child: any) =>
+              !value ||
+              child.props.children
+                .toLowerCase()
+                .startsWith(value.toLowerCase())
+          )}
+        </ul>
+      </div>
+    );
+  }
+);
+CustomMenu.displayName = 'CustomMenu';
+
+interface FilterDropdownProps {
+  label: string;
+  options: string[];
+  onSelect?: (value: string | null) => void;
+}
+
+export function FilterDropdown({ label, options, onSelect }: FilterDropdownProps) {
+  return (
+    <Dropdown onSelect={onSelect}>
+      <Dropdown.Toggle as={CustomToggle} id={`dropdown-${label}`}>
+        {label}
+      </Dropdown.Toggle>
+      <Dropdown.Menu as={CustomMenu}>
+        {options.map((opt) => (
+          <Dropdown.Item eventKey={opt} key={opt}>
+            {opt}
+          </Dropdown.Item>
+        ))}
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+}
+
+export default FilterDropdown;


### PR DESCRIPTION
## Summary
- add config-driven filter utilities to combine multiple Prisma where clauses across related models
- update candidate dashboard to build filter config and query professionals with all active filters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a917597b1c8325b585457c4508d1bd