### PR TITLE
Enable client-side filtering on candidate dashboard

### DIFF
--- a/src/app/api/bookings/upcoming.ts
+++ b/src/app/api/bookings/upcoming.ts
@@ -1,0 +1,15 @@
+import { prisma } from "../../../../lib/db";
+
+export async function getUpcomingCalls(candidateId: string) {
+  return prisma.booking.findMany({
+    where: {
+      candidateId,
+      startAt: { gte: new Date() },
+    },
+    include: {
+      professional: { include: { professionalProfile: true } },
+    },
+    orderBy: { startAt: 'asc' },
+  });
+}
+

--- a/src/app/api/professionals/list.ts
+++ b/src/app/api/professionals/list.ts
@@ -1,0 +1,8 @@
+import { prisma } from "../../../../lib/db";
+
+export async function listProfessionals() {
+  return prisma.user.findMany({
+    include: { professionalProfile: true, bookingsAsProfessional: true },
+  });
+}
+

--- a/src/app/candidate/dashboard/page.tsx
+++ b/src/app/candidate/dashboard/page.tsx
@@ -1,26 +1,11 @@
-import Link from "next/link";
-import { Card, Button, DataTable } from "../../../components/ui";
-import FilterDropdown from "../../../components/FilterDropdown";
-import {
-  getFilterOptions,
-  buildFilterWhere,
-  FilterConfig,
-} from "../../../app/api/filterOptions";
-import { prisma } from "../../../../lib/db";
+import { auth } from "../../../../auth";
+import { getFilterOptions, FilterConfig } from "../../../app/api/filterOptions";
+import { listProfessionals } from "../../../app/api/professionals/list";
+import { getUpcomingCalls } from "../../../app/api/bookings/upcoming";
+import DashboardClient from "../../../components/DashboardClient";
+import UpcomingCalls from "../../../components/UpcomingCalls";
 
-const upcoming = [
-  { name: "Ethan Harper", title: "Senior Consultant at Global Consulting Firm" },
-  { name: "Olivia Bennett", title: "Finance Manager at Tech Innovators Inc." },
-  { name: "Noah Carter", title: "Independent Strategy Advisor" },
-  { name: "Ava Morgan", title: "Principal at Investment Group" },
-  { name: "Liam Foster", title: "Consulting Partner at Top Tier Firm" },
-];
-
-export default async function CandidateDashboard({
-  searchParams,
-}: {
-  searchParams?: Record<string, string | string[]>;
-}) {
+export default async function CandidateDashboard() {
   const filterConfig: FilterConfig = {
     Industry: {
       model: "professionalProfile",
@@ -55,76 +40,57 @@ export default async function CandidateDashboard({
   };
 
   const filterOptions = await getFilterOptions(filterConfig);
+  const results = await listProfessionals();
 
-  const activeFilters: Record<string, string[]> = {};
-  for (const key of Object.keys(filterConfig)) {
-    const value = searchParams?.[key];
-    activeFilters[key] = Array.isArray(value)
-      ? value
-      : value
-      ? [value]
-      : [];
-  }
+  const session = await auth();
+  const upcomingCalls = session?.user.id
+    ? await getUpcomingCalls(session.user.id)
+    : [];
 
-  const where = buildFilterWhere(filterConfig, activeFilters);
-  const results = await prisma.user.findMany({
-    where,
-    include: { professionalProfile: true },
-  });
+  const availabilityTransform = filterConfig["Availability"].transform!;
+
+  const rows = results.map((u) => ({
+    name: { label: u.email, href: `/candidate/detail/${u.id}` },
+    title: u.professionalProfile?.title ?? "",
+    firm: u.professionalProfile?.employer ?? "",
+    experience: u.professionalProfile?.seniority ?? "",
+    availability: availabilityTransform(
+      u.bookingsAsProfessional.map((b) => b.startAt as Date)
+    ),
+    action: { label: "View Profile", href: `/candidate/detail/${u.id}` },
+  }));
+
+  const columns = [
+    { key: "name", label: "Name" },
+    { key: "title", label: "Title" },
+    { key: "experience", label: "Experience" },
+    { key: "availability", label: "Availability" },
+    { key: "action", label: "" },
+  ];
+
+  const clientFilterConfig: FilterConfig = {
+    Industry: { field: "title" },
+    Firm: { field: "firm" },
+    "Experience Level": { field: "experience" },
+    Availability: { field: "availability", many: true },
+  };
+
   return (
-      <div className="row" style={{ alignItems: "flex-start", gap: 24 }}>
-        <aside style={{ width: 260 }}>
-          <Card className="col" style={{ padding: 16 }}>
-            <h3>Upcoming Calls</h3>
-            <div className="col" style={{ gap: 12 }}>
-              {upcoming.map((u) => (
-                <div
-                  key={u.name}
-                  className="row"
-                  style={{ justifyContent: "space-between" }}
-                >
-                  <div className="col" style={{ gap: 2 }}>
-                    <strong>{u.name}</strong>
-                    <span style={{ color: "var(--text-muted)" }}>{u.title}</span>
-                  </div>
-                  <Button>Join</Button>
-                </div>
-              ))}
-            </div>
-          </Card>
-        </aside>
-        <section className="col" style={{ gap: 16, flex: 1 }}>
-          <h2>Search Results</h2>
-          <p style={{ color: "var(--text-muted)" }}>
-            Showing results for your search criteria
-          </p>
-          <div className="row" style={{ gap: 8, flexWrap: "wrap" }}>
-            {Object.entries(filterOptions).map(([label, options]) => (
-              <FilterDropdown key={label} label={label} options={options} />
-            ))}
-          </div>
-          <Card style={{ padding: 0 }}>
-            <DataTable
-              columns={[
-                { key: "name", label: "Name" },
-                { key: "title", label: "Title" },
-                { key: "experience", label: "Experience" },
-                { key: "availability", label: "Availability" },
-                { key: "action", label: "" },
-              ]}
-              rows={results.map((u) => ({
-                id: u.id,
-                name: u.email,
-                title: u.professionalProfile?.title ?? "",
-                experience: u.professionalProfile?.seniority ?? "",
-                availability: "",
-                action: (
-                  <Link href={`/candidate/detail/${u.id}`}>View Profile</Link>
-                ),
-              }))}
-            />
-          </Card>
-        </section>
-      </div>
+    <div className="row" style={{ alignItems: "flex-start", gap: 24 }}>
+      <aside style={{ width: 260 }}>
+        <UpcomingCalls calls={upcomingCalls} />
+      </aside>
+      <section className="col" style={{ gap: 16, flex: 1 }}>
+        <h2>Search Results</h2>
+        <DashboardClient
+          data={rows}
+          columns={columns}
+          filterOptions={filterOptions}
+          filterConfig={clientFilterConfig}
+          buttonColumns={["action"]}
+        />
+      </section>
+    </div>
   );
 }
+

--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState, ReactNode } from 'react';
+import { Card, Button, DataTable } from './ui';
+import FilterDropdown from './FilterDropdown';
+import {
+  applyFilters,
+  ActiveFilters,
+  FilterConfig,
+} from '../app/api/filterOptions';
+
+interface LinkValue {
+  label: string;
+  href?: string;
+}
+
+type RowData = Record<string, string | string[] | LinkValue>;
+
+interface Column {
+  key: string;
+  label: string;
+}
+
+interface Props {
+  data: RowData[];
+  columns: Column[];
+  filterOptions?: Record<string, string[]>;
+  filterConfig?: FilterConfig;
+  showFilters?: boolean;
+  buttonColumns?: string[];
+}
+
+export default function DashboardClient({
+  data,
+  columns,
+  filterOptions = {},
+  filterConfig,
+  showFilters = true,
+  buttonColumns = [],
+}: Props) {
+  const [active, setActive] = useState<ActiveFilters>(
+    showFilters
+      ? Object.fromEntries(Object.keys(filterOptions).map((k) => [k, []]))
+      : {}
+  );
+
+  const filtered = useMemo(() => {
+    if (!showFilters || !filterConfig) return data;
+    return applyFilters(data, filterConfig, active);
+  }, [data, filterConfig, active, showFilters]);
+
+  const tableRows = useMemo(() => {
+    return filtered.map((r) => {
+      const row: Record<string, ReactNode> = {};
+      columns.forEach((c) => {
+        const val = (r as any)[c.key];
+        if (
+          buttonColumns.includes(c.key) &&
+          val &&
+          typeof val === 'object' &&
+          'label' in val
+        ) {
+          const { label, href } = val as LinkValue;
+          row[c.key] = href ? (
+            <Link href={href}>
+              <Button>{label}</Button>
+            </Link>
+          ) : (
+            <Button>{label}</Button>
+          );
+        } else if (val && typeof val === 'object' && 'label' in val) {
+          row[c.key] = (val as LinkValue).label;
+        } else if (Array.isArray(val)) {
+          row[c.key] = val.join(', ');
+        } else {
+          row[c.key] = val as ReactNode;
+        }
+      });
+      return row;
+    });
+  }, [filtered, columns, buttonColumns]);
+
+  const handleChange = (label: string, values: string[]) => {
+    if (!showFilters) return;
+    setActive((prev) => ({ ...prev, [label]: values }));
+  };
+
+  return (
+    <div className="col" style={{ gap: 16 }}>
+      {showFilters && (
+        <>
+          <p style={{ color: 'var(--text-muted)' }}>
+            Showing results for your search criteria
+          </p>
+          <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+            {Object.entries(filterOptions).map(([label, options]) => (
+              <FilterDropdown
+                key={label}
+                label={label}
+                options={options}
+                onChange={(vals) => handleChange(label, vals)}
+              />
+            ))}
+          </div>
+        </>
+      )}
+      <Card style={{ padding: 0 }}>
+        <DataTable columns={columns as any} rows={tableRows as any} />
+      </Card>
+    </div>
+  );
+}
+

--- a/src/components/UpcomingCalls.tsx
+++ b/src/components/UpcomingCalls.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Card, Button } from './ui';
+import React from 'react';
+
+interface Call {
+  id: string;
+  startAt: string | Date;
+  zoomJoinUrl?: string | null;
+  professional: {
+    email: string;
+    professionalProfile?: {
+      title: string | null;
+    } | null;
+  };
+}
+
+export default function UpcomingCalls({ calls }: { calls: Call[] }) {
+  return (
+    <Card className="col" style={{ padding: 16 }}>
+      <h3>Upcoming Calls</h3>
+      <div className="col" style={{ gap: 12 }}>
+        {calls.map((c) => (
+          <div
+            key={c.id}
+            className="row"
+            style={{ justifyContent: 'space-between' }}
+          >
+            <div className="col" style={{ gap: 2 }}>
+              <strong>{c.professional.email}</strong>
+              <span style={{ color: 'var(--text-muted)' }}>
+                {c.professional.professionalProfile?.title ?? ''}
+              </span>
+              <span style={{ color: 'var(--text-muted)' }}>
+                {new Date(c.startAt).toLocaleString()}
+              </span>
+            </div>
+            <Button
+              onClick={() =>
+                c.zoomJoinUrl && window.open(c.zoomJoinUrl, '_blank')
+              }
+            >
+              Join
+            </Button>
+          </div>
+        ))}
+        {calls.length === 0 && (
+          <span style={{ color: 'var(--text-muted)' }}>No upcoming calls</span>
+        )}
+      </div>
+    </Card>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Move dashboard data queries to dedicated API helpers for professionals and upcoming calls
- Centralize filter logic in `filterOptions.ts` and expose reusable `DashboardClient`
- Render candidate dashboard using generic component and upcoming calls sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3313b2808325a805832abae5e2da