### PR TITLE
Restrict candidate dashboard to professionals with role filter

### DIFF
--- a/src/app/api/professionals/list.ts
+++ b/src/app/api/professionals/list.ts
@@ -1,8 +1,0 @@
-import { prisma } from "../../../../lib/db";
-
-export async function listProfessionals() {
-  return prisma.user.findMany({
-    include: { professionalProfile: true, bookingsAsProfessional: true },
-  });
-}
-

--- a/src/app/api/users/list.ts
+++ b/src/app/api/users/list.ts
@@ -1,0 +1,14 @@
+import { prisma } from "../../../../lib/db";
+import { Role } from "@prisma/client";
+
+export async function listUsers(roles: Role[] = [Role.PROFESSIONAL]) {
+  return prisma.user.findMany({
+    where: { role: { in: roles } },
+    include: {
+      professionalProfile: true,
+      candidateProfile: true,
+      bookingsAsProfessional: true,
+      bookingsAsCandidate: true,
+    },
+  });
+}

--- a/src/app/candidate/browse/page.tsx
+++ b/src/app/candidate/browse/page.tsx
@@ -3,7 +3,8 @@ import {
   getFilterOptions,
   FilterConfig,
 } from "../../../app/api/filterOptions";
-import { listProfessionals } from "../../../app/api/professionals/list";
+import { listUsers } from "../../../app/api/users/list";
+import { Role } from "@prisma/client";
 
 export default async function Browse() {
   const filterConfig: FilterConfig = {
@@ -40,7 +41,8 @@ export default async function Browse() {
   };
 
   const filterOptions = await getFilterOptions(filterConfig);
-  const results = await listProfessionals();
+  // By default, only show professionals. Pass [Role.CANDIDATE] or both to customize.
+  const results = await listUsers([Role.PROFESSIONAL]);
   const availabilityTransform = filterConfig["Availability"].transform!;
 
   const rows = results.map((u) => ({

--- a/src/app/candidate/dashboard/page.tsx
+++ b/src/app/candidate/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "../../../../auth";
 import { getFilterOptions, FilterConfig } from "../../../app/api/filterOptions";
-import { listProfessionals } from "../../../app/api/professionals/list";
+import { listUsers } from "../../../app/api/users/list";
+import { Role } from "@prisma/client";
 import { getUpcomingCalls } from "../../../app/api/bookings/upcoming";
 import DashboardClient from "../../../components/DashboardClient";
 import UpcomingCalls from "../../../components/UpcomingCalls";
@@ -40,7 +41,8 @@ export default async function CandidateDashboard() {
   };
 
   const filterOptions = await getFilterOptions(filterConfig);
-  const results = await listProfessionals();
+  // Default to professionals only; adjust roles as needed.
+  const results = await listUsers([Role.PROFESSIONAL]);
 
   const session = await auth();
   const upcomingCalls = session?.user.id


### PR DESCRIPTION
## Summary
- add generic `listUsers` API with optional role filter to fetch candidates, professionals, or both
- update candidate dashboard and browse pages to request only professionals via the new API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa62184f5483259a6c0a0be597ec75