### PR TITLE
chore: optimize client components

### DIFF
--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -2,8 +2,12 @@
 
 import Link from 'next/link';
 import { useMemo, useState, ReactNode } from 'react';
-import { Card, Button, DataTable } from './ui';
-import FilterDropdown from './FilterDropdown';
+import dynamic from 'next/dynamic';
+import { Card, Button } from './ui';
+const FilterDropdown = dynamic(() => import('./FilterDropdown'), { ssr: false });
+const DataTable = dynamic(() => import('./ui').then((m) => m.DataTable), {
+  ssr: false,
+});
 import {
   applyFilters,
   ActiveFilters,

--- a/src/components/FilterDropdown.tsx
+++ b/src/components/FilterDropdown.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, memo } from 'react';
 
 interface FilterDropdownProps {
   label: string;
@@ -19,7 +19,7 @@ interface FilterDropdownProps {
  * - Multi-select with checkboxes and "Select all"
  * - Selected options appear at the top of the list and inside the toggle
  */
-export default function FilterDropdown({
+function FilterDropdownComponent({
   label,
   options,
   onChange,
@@ -153,4 +153,6 @@ export default function FilterDropdown({
     </div>
   );
 }
+
+export default memo(FilterDropdownComponent);
 

--- a/src/components/layouts.tsx
+++ b/src/components/layouts.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { signOutAction } from '../actions';
 
 type ShellProps = { children: React.ReactNode; session?: any };
@@ -139,6 +140,12 @@ export function AdminShell({ children }: ShellProps) {
 }
 
 function Nav({ items }: { items: { href: string; label: string }[] }) {
+  const router = useRouter();
+
+  React.useEffect(() => {
+    items.forEach((item) => router.prefetch(item.href));
+  }, [items, router]);
+
   return (
     <nav className="col">
       {items.map((i) => (

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { memo } from 'react';
 import clsx from 'clsx';
 
 export function Button(props: React.ButtonHTMLAttributes<HTMLButtonElement> & {variant?: 'primary'|'danger'|'muted'}){
@@ -27,12 +27,18 @@ export function Badge({children}:{children:React.ReactNode}){
   return <span className="badge">{children}</span>
 }
 
-export function DataTable<T extends Record<string, React.ReactNode>>({columns, rows}:{columns:{key:keyof T, label:string}[], rows:T[]}){
+function DataTableComponent<T extends Record<string, React.ReactNode>>({
+  columns,
+  rows,
+}: {
+  columns: { key: keyof T; label: string }[];
+  rows: T[];
+}) {
   return (
     <table className="table">
       <thead>
         <tr>
-          {columns.map(c => (
+          {columns.map((c) => (
             <th key={String(c.key)}>{c.label}</th>
           ))}
         </tr>
@@ -40,7 +46,7 @@ export function DataTable<T extends Record<string, React.ReactNode>>({columns, r
       <tbody>
         {rows.map((r, i) => (
           <tr key={i}>
-            {columns.map(c => (
+            {columns.map((c) => (
               <td key={String(c.key)}>{r[c.key]}</td>
             ))}
           </tr>
@@ -49,3 +55,5 @@ export function DataTable<T extends Record<string, React.ReactNode>>({columns, r
     </table>
   );
 }
+
+export const DataTable = memo(DataTableComponent) as typeof DataTableComponent;


### PR DESCRIPTION
## Summary
- lazy load FilterDropdown and DataTable to shrink initial bundles
- memoize dropdown and table components to reduce re-renders
- prefetch sidebar routes on mount for faster navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa7b7cb6c0832596aa16e7c742b1a9