### PR TITLE
Optimize candidate data fetching

### DIFF
--- a/src/app/candidate/browse/page.tsx
+++ b/src/app/candidate/browse/page.tsx
@@ -40,9 +40,11 @@ export default async function Browse() {
     },
   };
 
-  const filterOptions = await getFilterOptions(filterConfig);
-  // By default, only show professionals. Pass [Role.CANDIDATE] or both to customize.
-  const results = await listUsers([Role.PROFESSIONAL]);
+  const [filterOptions, results] = await Promise.all([
+    getFilterOptions(filterConfig),
+    // By default, only show professionals. Pass [Role.CANDIDATE] or both to customize.
+    listUsers([Role.PROFESSIONAL]),
+  ]);
   const availabilityTransform = filterConfig["Availability"].transform!;
 
   const rows = results.map((u) => ({

--- a/src/app/candidate/dashboard/page.tsx
+++ b/src/app/candidate/dashboard/page.tsx
@@ -40,11 +40,13 @@ export default async function CandidateDashboard() {
     },
   };
 
-  const filterOptions = await getFilterOptions(filterConfig);
-  // Default to professionals only; adjust roles as needed.
-  const results = await listUsers([Role.PROFESSIONAL]);
+  const [filterOptions, results, session] = await Promise.all([
+    getFilterOptions(filterConfig),
+    // Default to professionals only; adjust roles as needed.
+    listUsers([Role.PROFESSIONAL]),
+    auth(),
+  ]);
 
-  const session = await auth();
   const upcomingCalls = session?.user.id
     ? await getUpcomingCalls(session.user.id)
     : [];


### PR DESCRIPTION
## Summary
- parallelize candidate dashboard data fetching with Promise.all
- fetch browse page filters and user list concurrently

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfc7366488325ab790b2c3e5374de