### PR TITLE
feat: dynamic professional detail page

### DIFF
--- a/src/app/api/professionals/[id]/route.ts
+++ b/src/app/api/professionals/[id]/route.ts
@@ -21,6 +21,7 @@ export async function GET(req: NextRequest, { params }:{params:{id:string}}){
     seniority: pro.seniority,
     priceUSD: pro.priceUSD,
     tags: [],
+    verified: !!pro.verifiedAt,
   };
   if(reveal){
     payload.identity = { name: 'Revealed User', email: 'pro@example.com' };

--- a/src/app/candidate/detail/[id]/page.tsx
+++ b/src/app/candidate/detail/[id]/page.tsx
@@ -1,36 +1,124 @@
 import { Button, Card, Badge } from "../../../../components/ui";
+import Image from "next/image";
 
-export default function Detail(){
+interface ProfessionalResponse {
+  identity: { name?: string; email?: string; redacted?: boolean };
+  employer: string;
+  title: string;
+  seniority: string;
+  priceUSD: number;
+  tags: string[];
+  verified?: boolean;
+  bio?: string;
+  experience?: { role: string; company: string; period?: string }[];
+  education?: { school: string; degree: string; period?: string }[];
+  interests?: string[];
+  activities?: string[];
+}
+
+export default async function Detail({ params }: { params: { id: string } }) {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ""}/api/professionals/${params.id}` , { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error("Failed to load professional profile");
+  }
+  const pro: ProfessionalResponse = await res.json();
+
+  const name = pro.identity.redacted ? "Professional" : pro.identity.name;
+  const contactInfo = pro.identity.redacted
+    ? "Identity redacted until booking is confirmed."
+    : pro.identity.email;
+
   return (
-      <section className="col" style={{gap:16}}>
-        <div className="row" style={{justifyContent:'space-between'}}>
-          <div className="col">
-            <h2>Finance Professional</h2>
-            <span className="badge">Verified Expert</span>
-            <span style={{color:'var(--text-muted)'}}>Identity redacted until booking is confirmed.</span>
+    <section className="col" style={{ gap: 16 }}>
+      <div className="row" style={{ justifyContent: "space-between" }}>
+        <div className="row" style={{ gap: 16, alignItems: "center" }}>
+          <div
+            style={{
+              width: 80,
+              height: 80,
+              borderRadius: "50%",
+              overflow: "hidden",
+              background: "var(--gray-200)",
+            }}
+          >
+            <Image
+              src="/globe.svg"
+              alt={name || "avatar"}
+              width={80}
+              height={80}
+            />
           </div>
-          <Button>Schedule a Call</Button>
+          <div className="col" style={{ gap: 4 }}>
+            <h2>{name}</h2>
+            <div className="row" style={{ alignItems: "center", gap: 8 }}>
+              <span>{pro.title}</span>
+              {pro.verified && <Badge>Verified Expert</Badge>}
+            </div>
+            <span style={{ color: "var(--text-muted)" }}>{contactInfo}</span>
+          </div>
         </div>
+        <Button>Schedule a Call</Button>
+      </div>
 
-        <div className="row" style={{gap:16}}>
-          <a className="badge">About</a>
-          <a className="badge">Reviews</a>
-        </div>
+      <div className="row" style={{ gap: 16 }}>
+        <a className="badge">About</a>
+        <a className="badge">Reviews</a>
+      </div>
 
-        <Card className="col" style={{padding:16, gap:16}}>
-          <h3>Summary</h3>
-          <p>Experienced finance professional with a strong background in investment banking and financial analysis. Proven track record of success in managing portfolios, conducting market research, and providing strategic financial advice.</p>
-          <h3>Experience</h3>
-          <ul>
-            <li>Senior Financial Analyst at Global Investments Inc. (2018 - Present)</li>
-            <li>Financial Analyst at Regional Bank Corp. (2016 - 2018)</li>
-          </ul>
-          <h3>Education</h3>
-          <ul>
-            <li>MBA in Finance, University of Business</li>
-            <li>B.S. in Economics, State University</li>
-          </ul>
-        </Card>
-      </section>
-  )
+      <Card className="col" style={{ padding: 16, gap: 16 }}>
+        <h3>Summary</h3>
+        <p>{pro.bio ?? "Summary available after booking is confirmed."}</p>
+
+        {pro.experience && pro.experience.length > 0 && (
+          <>
+            <h3>Experience</h3>
+            <ul>
+              {pro.experience.map((item, idx) => (
+                <li key={idx}>
+                  {item.role} at {item.company}
+                  {item.period ? ` (${item.period})` : ""}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+
+        {pro.education && pro.education.length > 0 && (
+          <>
+            <h3>Education</h3>
+            <ul>
+              {pro.education.map((item, idx) => (
+                <li key={idx}>
+                  {item.degree}, {item.school}
+                  {item.period ? ` (${item.period})` : ""}
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+
+        {pro.interests && pro.interests.length > 0 && (
+          <>
+            <h3>Interests</h3>
+            <div className="row" style={{ gap: 8, flexWrap: "wrap" }}>
+              {pro.interests.map((interest) => (
+                <Badge key={interest}>{interest}</Badge>
+              ))}
+            </div>
+          </>
+        )}
+
+        {pro.activities && pro.activities.length > 0 && (
+          <>
+            <h3>Activities</h3>
+            <ul>
+              {pro.activities.map((activity, idx) => (
+                <li key={idx}>{activity}</li>
+              ))}
+            </ul>
+          </>
+        )}
+      </Card>
+    </section>
+  );
 }


### PR DESCRIPTION
## Summary
- Render professional detail page with dynamic data from `/api/professionals/[id]`
- Expose verification status via professional API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acfd54d31c83258e79b08fc774471b