### PR TITLE
fix: use absolute URL for professional detail fetch

### DIFF
--- a/src/app/candidate/detail/[id]/page.tsx
+++ b/src/app/candidate/detail/[id]/page.tsx
@@ -17,7 +17,10 @@ interface ProfessionalResponse {
 }
 
 export default async function Detail({ params }: { params: { id: string } }) {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_URL ?? ""}/api/professionals/${params.id}` , { cache: "no-store" });
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const res = await fetch(`${baseUrl}/api/professionals/${params.id}`, {
+    cache: "no-store",
+  });
   if (!res.ok) {
     throw new Error("Failed to load professional profile");
   }


### PR DESCRIPTION
## Summary
- ensure candidate detail page uses absolute base URL when fetching professional data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad00a204c8832589fcc07003b46afd