### PR TITLE
feat: structure profile experience and education

### DIFF
--- a/lib/profileOptions.ts
+++ b/lib/profileOptions.ts
@@ -1,0 +1,27 @@
+export const SCHOOLS = [
+  'Harvard Business School',
+  'Wharton',
+  'New York University',
+  'Stanford University',
+  'London School of Economics',
+];
+
+export const JOB_TITLES = [
+  'Analyst',
+  'Associate',
+  'Vice President',
+  'Consultant',
+  'Research Analyst',
+];
+
+export const DEGREE_TITLES = [
+  'MBA',
+  'BBA',
+  'BS in Economics',
+  'BA in Finance',
+  'Masters in Finance',
+];
+
+// Options for user selection including a fallback 'Other'
+export const SCHOOL_OPTIONS = [...SCHOOLS, 'Other'];
+export const TITLE_OPTIONS = [...JOB_TITLES, ...DEGREE_TITLES, 'Other'];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -83,17 +83,17 @@ model OAuthAccount {
 }
 
 model ProfessionalProfile {
-  userId            String  @id
+  userId            String @id
   employer          String
   title             String
   seniority         String
   bio               String
   priceUSD          Int
-  availabilityPrefs Json    @default("{}")
+  availabilityPrefs Json   @default("{}")
   verifiedAt        DateTime?
   corporateEmail    String?
-  experience        String[]
-  education         String[]
+  experience        Experience[] @relation("ProfessionalExperience")
+  education         Education[]  @relation("ProfessionalEducation")
   interests         String[]
   activities        String[]
 
@@ -102,13 +102,37 @@ model ProfessionalProfile {
 
 model CandidateProfile {
   userId     String @id
-  experience Json  @default("[]")
-  education  Json  @default("[]")
   resumeUrl  String?
   interests         String[]
   activities        String[]
-  
+  experience Experience[] @relation("CandidateExperience")
+  education  Education[]  @relation("CandidateEducation")
+
   user       User  @relation(fields:[userId], references:[id], onDelete: Cascade)
+}
+
+model Experience {
+  id            String   @id @default(cuid())
+  firm          String
+  title         String
+  startDate     DateTime
+  endDate       DateTime
+  professional  ProfessionalProfile? @relation("ProfessionalExperience", fields:[professionalId], references:[userId], onDelete: Cascade)
+  professionalId String?
+  candidate     CandidateProfile?    @relation("CandidateExperience", fields:[candidateId], references:[userId], onDelete: Cascade)
+  candidateId   String?
+}
+
+model Education {
+  id            String   @id @default(cuid())
+  school        String
+  title         String
+  startDate     DateTime
+  endDate       DateTime
+  professional  ProfessionalProfile? @relation("ProfessionalEducation", fields:[professionalId], references:[userId], onDelete: Cascade)
+  professionalId String?
+  candidate     CandidateProfile?    @relation("CandidateEducation", fields:[candidateId], references:[userId], onDelete: Cascade)
+  candidateId   String?
 }
 
 model Booking {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, Role, BookingStatus, PaymentStatus, QCStatus } from '@prisma/client';
 import bcrypt from 'bcryptjs';
+import { SCHOOLS, JOB_TITLES, DEGREE_TITLES } from '../lib/profileOptions';
 
 const prisma = new PrismaClient();
 
@@ -22,7 +23,57 @@ const firms = [
   'Bain & Company',
 ];
 
-const titles = ['Analyst', 'Associate', 'Vice President'];
+type TenorPeriod = { start: string; finish: string };
+type ExperienceEntry = { firm: string; title: string; startDate: string; endDate: string };
+type EducationEntry = { school: string; title: string; startDate: string; endDate: string };
+
+const jobTitles = JOB_TITLES;
+const degreeTitles = DEGREE_TITLES;
+const schools = SCHOOLS;
+
+const experiencePeriods: TenorPeriod[] = [
+  { start: '2018-01-01', finish: '2019-01-01' },
+  { start: '2019-01-01', finish: '2020-01-01' },
+  { start: '2020-01-01', finish: '2021-01-01' },
+  { start: '2021-01-01', finish: '2022-01-01' },
+  { start: '2022-01-01', finish: '2023-01-01' },
+];
+const educationPeriods: TenorPeriod[] = [
+  { start: '2014-09-01', finish: '2018-06-01' },
+  { start: '2015-09-01', finish: '2019-06-01' },
+  { start: '2016-09-01', finish: '2020-06-01' },
+  { start: '2017-09-01', finish: '2021-06-01' },
+  { start: '2018-09-01', finish: '2022-06-01' },
+];
+
+const randomPeriod = (periods: TenorPeriod[]): TenorPeriod => pick(periods);
+
+const randomExperience = (): ExperienceEntry => {
+  const period = randomPeriod(experiencePeriods);
+  return {
+    firm: pick(firms),
+    title: pick(jobTitles),
+    startDate: period.start,
+    endDate: period.finish,
+  };
+};
+
+const randomEducation = (): EducationEntry => {
+  const period = randomPeriod(educationPeriods);
+  return {
+    school: pick(schools),
+    title: pick(degreeTitles),
+    startDate: period.start,
+    endDate: period.finish,
+  };
+};
+
+// mock profile details
+const candidateInterests = ['Investment Banking', 'Private Equity', 'Consulting', 'Startups', 'Hedge Funds'];
+const candidateActivities = ['Finance club', 'Case competitions', 'Volunteering', 'Blogging', 'Sports'];
+
+const professionalInterests = ['Mergers and Acquisitions', 'Private Equity', 'Venture Capital', 'FinTech', 'Consulting'];
+const professionalActivities = ['Mentoring', 'Volunteering', 'Cycling', 'Traveling', 'Blogging'];
 
 async function createCandidates() {
   const out = [];
@@ -41,7 +92,13 @@ async function createCandidates() {
   await prisma.candidateProfile.upsert({
     where: { userId: euisang.id },
     update: {},
-    create: { userId: euisang.id, experience: [], education: [] },
+    create: {
+      userId: euisang.id,
+      interests: [pick(candidateInterests), pick(candidateInterests)],
+      activities: [pick(candidateActivities)],
+      experience: { create: [randomExperience()] },
+      education: { create: [randomEducation()] },
+    },
   });
   out.push(euisang);
 
@@ -59,7 +116,13 @@ async function createCandidates() {
   await prisma.candidateProfile.upsert({
     where: { userId: victoria.id },
     update: {},
-    create: { userId: victoria.id, experience: [], education: [] },
+    create: {
+      userId: victoria.id,
+      interests: [pick(candidateInterests), pick(candidateInterests)],
+      activities: [pick(candidateActivities)],
+      experience: { create: [randomExperience()] },
+      education: { create: [randomEducation()] },
+    },
   });
   out.push(victoria);
 
@@ -74,7 +137,13 @@ async function createCandidates() {
       },
     });
     await prisma.candidateProfile.create({
-      data: { userId: user.id, experience: [], education: [] },
+      data: {
+        userId: user.id,
+        interests: [pick(candidateInterests), pick(candidateInterests)],
+        activities: [pick(candidateActivities)],
+        experience: { create: [randomExperience()] },
+        education: { create: [randomEducation()] },
+      },
     });
     out.push(user);
   }
@@ -99,11 +168,15 @@ async function createProfessionals() {
       data: {
         userId: user.id,
         employer: pick(firms),
-        title: pick(titles),
+        title: pick(jobTitles),
         seniority: pick(['Junior', 'Mid', 'Senior']),
         bio: 'Experienced finance professional with transaction and coverage background.',
         priceUSD: 80 + i,
         availabilityPrefs: {},
+        interests: [pick(professionalInterests), pick(professionalInterests)],
+        activities: [pick(professionalActivities)],
+        experience: { create: [randomExperience(), randomExperience()] },
+        education: { create: [randomEducation()] },
       },
     });
     out.push(user);


### PR DESCRIPTION
## Summary
- store experience and education as objects with firm/school, start-finish tenor, and title
- centralize selectable school and title options with "Other"
- seed profiles with structured experience, education, interests and activities

## Testing
- `npx prisma generate`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad1f2e01c08325a9ce10316df84528