### PR TITLE
Use real candidate data on settings page

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ See `.env.example` for all required variables and flags. **Exactly these feature
 - `FEATURE_SUCCESS_FEE` (default: true)
 - `FEATURE_QC_LLM` (default: true)
 
+Resumes are served from AWS S3. Provide `AWS_S3_BUCKET` and AWS credentials
+(`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_REGION`) in
+your environment so the settings page can sign and preview uploaded resumes.
+
 ---
 
 ## Migrations & Seeding

--- a/lib/s3.ts
+++ b/lib/s3.ts
@@ -1,0 +1,12 @@
+import { S3Client } from "@aws-sdk/client-s3";
+
+export const s3 = new S3Client({
+  region: process.env.AWS_REGION || "us-east-1",
+  credentials: process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
+    ? {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      }
+    : undefined,
+});
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.873.0",
+        "@aws-sdk/s3-request-presigner": "^3.873.0",
         "@prisma/client": "^6.14.0",
         "@prisma/extension-accelerate": "^2.0.2",
         "bcryptjs": "^2.4.3",
@@ -71,11 +73,87 @@
         }
       }
     },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -91,7 +169,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -104,7 +181,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -118,7 +194,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -132,7 +207,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -147,7 +221,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -157,7 +230,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -169,7 +241,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -182,7 +253,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -196,7 +266,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -204,6 +273,498 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.873.0.tgz",
+      "integrity": "sha512-b+1lSEf+obcC508blw5qEDR1dyTiHViZXbf8G6nFospyqLJS0Vu2py+e+LG2VDVdAouZ8+RvW+uAi73KgsWl0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/credential-provider-node": "3.873.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.873.0",
+        "@aws-sdk/middleware-expect-continue": "3.873.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.873.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-location-constraint": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.873.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-sdk-s3": "3.873.0",
+        "@aws-sdk/middleware-ssec": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.873.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/signature-v4-multi-region": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.873.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.873.0",
+        "@aws-sdk/xml-builder": "3.873.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.8.0",
+        "@smithy/eventstream-serde-browser": "^4.0.5",
+        "@smithy/eventstream-serde-config-resolver": "^4.1.3",
+        "@smithy/eventstream-serde-node": "^4.0.5",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-blob-browser": "^4.0.5",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/hash-stream-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/md5-js": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-retry": "^4.1.19",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.26",
+        "@smithy/util-defaults-mode-node": "^4.0.26",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-stream": "^4.2.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-waiter": "^4.0.7",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sso": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.873.0.tgz",
+      "integrity": "sha512-EmcrOgFODWe7IsLKFTeSXM9TlQ80/BO1MBISlr7w2ydnOaUYIiPGRRJnDpeIgMaNqT4Rr2cRN2RiMrbFO7gDdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.873.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.873.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.873.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.873.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.8.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-retry": "^4.1.19",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.26",
+        "@smithy/util-defaults-mode-node": "^4.0.26",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.873.0.tgz",
+      "integrity": "sha512-WrROjp8X1VvmnZ4TBzwM7RF+EB3wRaY9kQJLXw+Aes0/3zRjUXvGIlseobGJMqMEGnM0YekD2F87UaVfot1xeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/xml-builder": "3.873.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.873.0.tgz",
+      "integrity": "sha512-FWj1yUs45VjCADv80JlGshAttUHBL2xtTAbJcAxkkJZzLRKVkdyrepFWhv/95MvDyzfbT6PgJiWMdW65l/8ooA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.873.0.tgz",
+      "integrity": "sha512-0sIokBlXIsndjZFUfr3Xui8W6kPC4DAeBGAXxGi9qbFZ9PWJjn1vt2COLikKH3q2snchk+AsznREZG8NW6ezSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-stream": "^4.2.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.873.0.tgz",
+      "integrity": "sha512-bQdGqh47Sk0+2S3C+N46aNQsZFzcHs7ndxYLARH/avYXf02Nl68p194eYFaAHJSQ1re5IbExU1+pbums7FJ9fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/credential-provider-env": "3.873.0",
+        "@aws-sdk/credential-provider-http": "3.873.0",
+        "@aws-sdk/credential-provider-process": "3.873.0",
+        "@aws-sdk/credential-provider-sso": "3.873.0",
+        "@aws-sdk/credential-provider-web-identity": "3.873.0",
+        "@aws-sdk/nested-clients": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.873.0.tgz",
+      "integrity": "sha512-+v/xBEB02k2ExnSDL8+1gD6UizY4Q/HaIJkNSkitFynRiiTQpVOSkCkA0iWxzksMeN8k1IHTE5gzeWpkEjNwbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.873.0",
+        "@aws-sdk/credential-provider-http": "3.873.0",
+        "@aws-sdk/credential-provider-ini": "3.873.0",
+        "@aws-sdk/credential-provider-process": "3.873.0",
+        "@aws-sdk/credential-provider-sso": "3.873.0",
+        "@aws-sdk/credential-provider-web-identity": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/credential-provider-imds": "^4.0.7",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.873.0.tgz",
+      "integrity": "sha512-ycFv9WN+UJF7bK/ElBq1ugWA4NMbYS//1K55bPQZb2XUpAM2TWFlEjG7DIyOhLNTdl6+CbHlCdhlKQuDGgmm0A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.873.0.tgz",
+      "integrity": "sha512-SudkAOZmjEEYgUrqlUUjvrtbWJeI54/0Xo87KRxm4kfBtMqSx0TxbplNUAk8Gkg4XQNY0o7jpG8tK7r2Wc2+uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.873.0",
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/token-providers": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.873.0.tgz",
+      "integrity": "sha512-Gw2H21+VkA6AgwKkBtTtlGZ45qgyRZPSKWs0kUwXVlmGOiPz61t/lBX0vG6I06ZIz2wqeTJ5OA1pWZLqw1j0JQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/nested-clients": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.873.0.tgz",
+      "integrity": "sha512-KZ/W1uruWtMOs7D5j3KquOxzCnV79KQW9MjJFZM/M0l6KI8J6V3718MXxFHsTjUE4fpdV6SeCNLV1lwGygsjJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.873.0.tgz",
+      "integrity": "sha512-QhNZ8X7pW68kFez9QxUSN65Um0Feo18ZmHxszQZNUhKDsXew/EG9NPQE/HgYcekcon35zHxC4xs+FeNuPurP2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.873.0.tgz",
+      "integrity": "sha512-OtgY8EXOzRdEWR//WfPkA/fXl0+WwE8hq0y9iw2caNyKPtca85dzrrZWnPqyBK/cpImosrpR1iKMYr41XshsCg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.873.0.tgz",
+      "integrity": "sha512-gHqAMYpWkPhZLwqB3Yj83JKdL2Vsb64sryo8LN2UdpElpS+0fT4yjqSxKTfp7gkhN6TCIxF24HQgbPk5FMYJWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.873.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.873.0.tgz",
+      "integrity": "sha512-yg8JkRHuH/xO65rtmLOWcd9XQhxX1kAonp2CliXT44eA/23OBds6XoheY44eZeHfCTgutDLTYitvy3k9fQY6ZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/middleware-host-header": "3.873.0",
+        "@aws-sdk/middleware-logger": "3.873.0",
+        "@aws-sdk/middleware-recursion-detection": "3.873.0",
+        "@aws-sdk/middleware-user-agent": "3.873.0",
+        "@aws-sdk/region-config-resolver": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-endpoints": "3.873.0",
+        "@aws-sdk/util-user-agent-browser": "3.873.0",
+        "@aws-sdk/util-user-agent-node": "3.873.0",
+        "@smithy/config-resolver": "^4.1.5",
+        "@smithy/core": "^3.8.0",
+        "@smithy/fetch-http-handler": "^5.1.1",
+        "@smithy/hash-node": "^4.0.5",
+        "@smithy/invalid-dependency": "^4.0.5",
+        "@smithy/middleware-content-length": "^4.0.5",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/middleware-retry": "^4.1.19",
+        "@smithy/middleware-serde": "^4.0.9",
+        "@smithy/middleware-stack": "^4.0.5",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/node-http-handler": "^4.1.1",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.26",
+        "@smithy/util-defaults-mode-node": "^4.0.26",
+        "@smithy/util-endpoints": "^3.0.7",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-retry": "^4.0.7",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.873.0.tgz",
+      "integrity": "sha512-q9sPoef+BBG6PJnc4x60vK/bfVwvRWsPgcoQyIra057S/QGjq5VkjvNk6H8xedf6vnKlXNBwq9BaANBXnldUJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/token-providers": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.873.0.tgz",
+      "integrity": "sha512-BWOCeFeV/Ba8fVhtwUw/0Hz4wMm9fjXnMb4Z2a5he/jFlz5mt1/rr6IQ4MyKgzOaz24YrvqsJW2a0VUKOaYDvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/nested-clients": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/shared-ini-file-loader": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.873.0.tgz",
+      "integrity": "sha512-YByHrhjxYdjKRf/RQygRK1uh0As1FIi9+jXTcIEX/rBgN8mUByczr2u4QXBzw7ZdbdcOBMOkPnLRjNOWW1MkFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/url-parser": "^4.0.5",
+        "@smithy/util-endpoints": "^3.0.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.873.0.tgz",
+      "integrity": "sha512-AcRdbK6o19yehEcywI43blIBhOCSo6UgyWcuOJX5CFF8k39xm1ILCjQlRRjchLAxWrm0lU0Q7XV90RiMMFMZtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/types": "^4.3.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.873.0.tgz",
+      "integrity": "sha512-9MivTP+q9Sis71UxuBaIY3h5jxH0vN3/ZWGxO8ADL19S2OIfknrYSAfzE5fpoKROVBu0bS4VifHOFq4PY1zsxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
+      "integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-ses": {
@@ -479,6 +1040,102 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.873.0.tgz",
+      "integrity": "sha512-b4bvr0QdADeTUs+lPc9Z48kXzbKHXQKgTvxx/jXDgSW9tv4KmYPO1gIj6Z9dcrBkRWQuUtSW3Tu2S5n6pe+zeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-arn-parser": "3.873.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-config-provider": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.873.0.tgz",
+      "integrity": "sha512-GIqoc8WgRcf/opBOZXFLmplJQKwOMjiOMmDz9gQkaJ8FiVJoAp8EGVmK2TOWZMQUYsavvHYsHaor5R2xwPoGVg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.873.0.tgz",
+      "integrity": "sha512-NNiy2Y876P5cgIhsDlHopbPZS3ugdfBW1va0WdpVBviwAs6KT4irPNPAOyF1/33N/niEDKx0fKQV7ROB70nNPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-stream": "^4.2.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/core": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.873.0.tgz",
+      "integrity": "sha512-WrROjp8X1VvmnZ4TBzwM7RF+EB3wRaY9kQJLXw+Aes0/3zRjUXvGIlseobGJMqMEGnM0YekD2F87UaVfot1xeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/xml-builder": "3.873.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
+      "integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.862.0.tgz",
@@ -488,6 +1145,20 @@
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
         "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.873.0.tgz",
+      "integrity": "sha512-r+hIaORsW/8rq6wieDordXnA/eAu7xAPLue2InhoEX6ML7irP52BgiibHLpt9R0psiCzIHhju8qqKa4pJOrmiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
         "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -519,6 +1190,84 @@
       "dependencies": {
         "@aws-sdk/types": "3.862.0",
         "@smithy/protocol-http": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.873.0.tgz",
+      "integrity": "sha512-bOoWGH57ORK2yKOqJMmxBV4b3yMK8Pc0/K2A98MNPuQedXaxxwzRfsT2Qw+PpfYkiijrrNFqDYmQRGntxJ2h8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-arn-parser": "3.873.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-stream": "^4.2.4",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.873.0.tgz",
+      "integrity": "sha512-WrROjp8X1VvmnZ4TBzwM7RF+EB3wRaY9kQJLXw+Aes0/3zRjUXvGIlseobGJMqMEGnM0YekD2F87UaVfot1xeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/xml-builder": "3.873.0",
+        "@smithy/core": "^3.8.0",
+        "@smithy/node-config-provider": "^4.1.4",
+        "@smithy/property-provider": "^4.0.5",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.5",
+        "@smithy/util-utf8": "^4.0.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
+      "integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.873.0.tgz",
+      "integrity": "sha512-AF55J94BoiuzN7g3hahy0dXTVZahVi8XxRBLgzNp6yQf0KTng+hb/V9UQZVYY1GZaDczvvvnqC54RGe9OZZ9zQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
         "@smithy/types": "^4.3.2",
         "tslib": "^2.6.2"
       },
@@ -613,6 +1362,42 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.873.0.tgz",
+      "integrity": "sha512-DiVlfCpdR7EaZSNPQwBB1jq8INWezKMWb3BUOWxrOcIcS3p2WpKbYl0H76D6TCHvQzXRVgKSSM6tHuWPoJtUHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@aws-sdk/util-format-url": "3.873.0",
+        "@smithy/middleware-endpoint": "^4.1.18",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/smithy-client": "^4.4.10",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.873.0.tgz",
+      "integrity": "sha512-FQ5OIXw1rmDud7f/VO9y2Mg9rX1o4MnngRKUOD8mS9ALK4uxKrTczb4jA+uJLSLwTqMGs3bcB1RzbMW1zWTMwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.873.0",
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/protocol-http": "^5.1.3",
+        "@smithy/signature-v4": "^5.1.3",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/token-providers": {
       "version": "3.864.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.864.0.tgz",
@@ -636,10 +1421,21 @@
       "version": "3.862.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.862.0.tgz",
       "integrity": "sha512-Bei+RL0cDxxV+lW2UezLbCYYNeJm6Nzee0TpW0FfyTRBhH9C1XQh4+x+IClriXvgBnRquTMMYsmJfvx8iyLKrg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.873.0.tgz",
+      "integrity": "sha512-qag+VTqnJWDn8zTAXX4wiVioa0hZDQMtbZcGRERVnLar4/3/VIKBhxX2XibNQXFu1ufgcRn4YntT/XEPecFWcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -663,11 +1459,25 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.873.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.873.0.tgz",
+      "integrity": "sha512-v//b9jFnhzTKKV3HFTw2MakdM22uBAs2lBov51BWmFXuFtSTdBLrR7zgfetQPE3PVkFai0cmtJQPdc3MX+T/cQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.862.0",
+        "@smithy/querystring-builder": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.804.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.804.0.tgz",
       "integrity": "sha512-zVoRfpmBVPodYlnMjgVjfGoEZagyRF5IPn3Uo6ZvOZp24chnW/FRstH7ESDHDDRga4z3V+ElUQHKpFDXWyBW5A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1888,10 +2698,34 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.5.tgz",
       "integrity": "sha512-jcrqdTQurIrBbUm4W2YdLVMQDoL0sA9DTxYd2s+R/y+2U9NLOP7Xf/YqfSg1FZhlZIYEnvk2mwbyvIfdLEPo8g==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.0.0.tgz",
+      "integrity": "sha512-+sKqDBQqb036hh4NPaUiEkYFkTUGYzRsn3EuFhyfQfMy6oGHEUJDurLP9Ufb5dasr/XiAmPNMr6wa9afjQB+Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.0.0.tgz",
+      "integrity": "sha512-R9wM2yPmfEMsUmlMlIgSzOyICs0x9uu7UTHoccMyt7BWw8shcGM8HqB355+BZCPBcySvbTYMs62EgEQkNxz2ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1902,7 +2736,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.5.tgz",
       "integrity": "sha512-viuHMxBAqydkB0AfWwHIdwf/PRH2z5KHGUzqyRtS/Wv+n3IHI993Sk76VCA7dD/+GzgGOmlJDITfPcJC1nIVIw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.4",
@@ -1919,7 +2752,6 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.8.0.tgz",
       "integrity": "sha512-EYqsIYJmkR1VhVE9pccnk353xhs+lB6btdutJEtsp7R055haMJp2yE16eSxw8fv+G0WUY6vqxyYOP8kOqawxYQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.0.9",
@@ -1942,7 +2774,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.7.tgz",
       "integrity": "sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.4",
@@ -1955,11 +2786,80 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.5.tgz",
+      "integrity": "sha512-miEUN+nz2UTNoRYRhRqVTJCx7jMeILdAurStT2XoS+mhokkmz1xAPp95DFW9Gxt4iF2VBqpeF9HbTQ3kY1viOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-hex-encoding": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.5.tgz",
+      "integrity": "sha512-LCUQUVTbM6HFKzImYlSB9w4xafZmpdmZsOh9rIl7riPC3osCgGFVP+wwvYVw6pXda9PPT9TcEZxaq3XE81EdJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.3.tgz",
+      "integrity": "sha512-yTTzw2jZjn/MbHu1pURbHdpjGbCuMHWncNBpJnQAPxOVnFUAbSIUSwafiphVDjNV93TdBJWmeVAds7yl5QCkcA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.5.tgz",
+      "integrity": "sha512-lGS10urI4CNzz6YlTe5EYG0YOpsSp3ra8MXyco4aqSkQDuyZPIw2hcaxDU82OUVtK7UY9hrSvgWtpsW5D4rb4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.5.tgz",
+      "integrity": "sha512-JFnmu4SU36YYw3DIBVao3FsJh4Uw65vVDIqlWT4LzR6gXA0F3KP0IXFKKJrhaVzCBhAuMsrUUaT5I+/4ZhF7aw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.0.5",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/fetch-http-handler": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.1.1.tgz",
       "integrity": "sha512-61WjM0PWmZJR+SnmzaKI7t7G0UkkNFboDpzIdzSoy7TByUzlxo18Qlh9s71qug4AY4hlH/CwXdubMtkcNEb/sQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.3",
@@ -1972,11 +2872,25 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.0.5.tgz",
+      "integrity": "sha512-F7MmCd3FH/Q2edhcKd+qulWkwfChHbc9nhguBlVjSUE6hVHhec3q6uPQ+0u69S6ppvLtR3eStfCuEKMXBXhvvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.0.0",
+        "@smithy/chunked-blob-reader-native": "^4.0.0",
+        "@smithy/types": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/hash-node": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.5.tgz",
       "integrity": "sha512-cv1HHkKhpyRb6ahD8Vcfb2Hgz67vNIXEp2vnhzfxLFGRukLCNEA5QdsorbUEzXma1Rco0u3rx5VTqbM06GcZqQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -1988,11 +2902,24 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.0.5.tgz",
+      "integrity": "sha512-IJuDS3+VfWB67UC0GU0uYBG/TA30w+PlOaSo0GPm9UHS88A6rCP6uZxNjNYiyRtOcjv7TXn/60cW8ox1yuZsLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-utf8": "^4.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@smithy/invalid-dependency": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.5.tgz",
       "integrity": "sha512-IVnb78Qtf7EJpoEVo7qJ8BEXQwgC4n3igeJNNKEj/MLYtapnx8A67Zt/J3RXAj2xSO1910zk0LdFiygSemuLow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -2006,9 +2933,22 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
       "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.0.5.tgz",
+      "integrity": "sha512-8n2XCwdUbGr8W/XhMTaxILkVlw2QebkVTn5tm3HOcbPbOpWg89zr6dPXsH8xbeTsbTXlJvlJNTQsKAIoqQGbdA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.3.2",
+        "@smithy/util-utf8": "^4.0.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -2019,7 +2959,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.5.tgz",
       "integrity": "sha512-l1jlNZoYzoCC7p0zCtBDE5OBXZ95yMKlRlftooE5jPWQn4YBPLgsp+oeHp7iMHaTGoUdFqmHOPa8c9G3gBsRpQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.3",
@@ -2034,7 +2973,6 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.18.tgz",
       "integrity": "sha512-ZhvqcVRPZxnZlokcPaTwb+r+h4yOIOCJmx0v2d1bpVlmP465g3qpVSf7wxcq5zZdu4jb0H4yIMxuPwDJSQc3MQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.8.0",
@@ -2054,7 +2992,6 @@
       "version": "4.1.19",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.19.tgz",
       "integrity": "sha512-X58zx/NVECjeuUB6A8HBu4bhx72EoUz+T5jTMIyeNKx2lf+Gs9TmWPNNkH+5QF0COjpInP/xSpJGJ7xEnAklQQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.4",
@@ -2076,7 +3013,6 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.9.tgz",
       "integrity": "sha512-uAFFR4dpeoJPGz8x9mhxp+RPjo5wW0QEEIPPPbLXiRRWeCATf/Km3gKIVR5vaP8bN1kgsPhcEeh+IZvUlBv6Xg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.1.3",
@@ -2091,7 +3027,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.5.tgz",
       "integrity": "sha512-/yoHDXZPh3ocRVyeWQFvC44u8seu3eYzZRveCMfgMOBcNKnAmOvjbL9+Cp5XKSIi9iYA9PECUuW2teDAk8T+OQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -2105,7 +3040,6 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.4.tgz",
       "integrity": "sha512-+UDQV/k42jLEPPHSn39l0Bmc4sB1xtdI9Gd47fzo/0PbXzJ7ylgaOByVjF5EeQIumkepnrJyfx86dPa9p47Y+w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.5",
@@ -2121,7 +3055,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.1.1.tgz",
       "integrity": "sha512-RHnlHqFpoVdjSPPiYy/t40Zovf3BBHc2oemgD7VsVTFFZrU5erFFe0n52OANZZ/5sbshgD93sOh5r6I35Xmpaw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.0.5",
@@ -2138,7 +3071,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.5.tgz",
       "integrity": "sha512-R/bswf59T/n9ZgfgUICAZoWYKBHcsVDurAGX88zsiUtOTA/xUAPyiT+qkNCPwFn43pZqN84M4MiUsbSGQmgFIQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -2152,7 +3084,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.3.tgz",
       "integrity": "sha512-fCJd2ZR7D22XhDY0l+92pUag/7je2BztPRQ01gU5bMChcyI0rlly7QFibnYHzcxDvccMjlpM/Q1ev8ceRIb48w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -2166,7 +3097,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.5.tgz",
       "integrity": "sha512-NJeSCU57piZ56c+/wY+AbAw6rxCCAOZLCIniRE7wqvndqxcKKDOXzwWjrY7wGKEISfhL9gBbAaWWgHsUGedk+A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -2181,7 +3111,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.5.tgz",
       "integrity": "sha512-6SV7md2CzNG/WUeTjVe6Dj8noH32r4MnUeFKZrnVYsQxpGSIcphAanQMayi8jJLZAWm6pdM9ZXvKCpWOsIGg0w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -2195,7 +3124,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.7.tgz",
       "integrity": "sha512-XvRHOipqpwNhEjDf2L5gJowZEm5nsxC16pAZOeEcsygdjv9A2jdOh3YoDQvOXBGTsaJk6mNWtzWalOB9976Wlg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2"
@@ -2208,7 +3136,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.5.tgz",
       "integrity": "sha512-YVVwehRDuehgoXdEL4r1tAAzdaDgaC9EQvhK0lEbfnbrd0bd5+CTQumbdPryX3J2shT7ZqQE+jPW4lmNBAB8JQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -2222,7 +3149,6 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
       "integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
@@ -2242,7 +3168,6 @@
       "version": "4.4.10",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.10.tgz",
       "integrity": "sha512-iW6HjXqN0oPtRS0NK/zzZ4zZeGESIFcxj2FkWed3mcK8jdSdHzvnCKXSjvewESKAgGKAbJRA+OsaqKhkdYRbQQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.8.0",
@@ -2261,7 +3186,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.2.tgz",
       "integrity": "sha512-QO4zghLxiQ5W9UZmX2Lo0nta2PuE1sSrXUYDoaB6HMR762C0P7v/HEPHf6ZdglTVssJG1bsrSBxdc3quvDSihw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2274,7 +3198,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.5.tgz",
       "integrity": "sha512-j+733Um7f1/DXjYhCbvNXABV53NyCRRA54C7bNEIxNPs0YjfRxeMKjjgm2jvTYrciZyCjsicHwQ6Q0ylo+NAUw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^4.0.5",
@@ -2289,7 +3212,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
       "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -2304,7 +3226,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
       "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2317,7 +3238,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
       "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2330,7 +3250,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
       "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.0.0",
@@ -2344,7 +3263,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
       "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2357,7 +3275,6 @@
       "version": "4.0.26",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.26.tgz",
       "integrity": "sha512-xgl75aHIS/3rrGp7iTxQAOELYeyiwBu+eEgAk4xfKwJJ0L8VUjhO2shsDpeil54BOFsqmk5xfdesiewbUY5tKQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.5",
@@ -2374,7 +3291,6 @@
       "version": "4.0.26",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.26.tgz",
       "integrity": "sha512-z81yyIkGiLLYVDetKTUeCZQ8x20EEzvQjrqJtb/mXnevLq2+w3XCEWTJ2pMp401b6BkEkHVfXb/cROBpVauLMQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.1.5",
@@ -2393,7 +3309,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.7.tgz",
       "integrity": "sha512-klGBP+RpBp6V5JbrY2C/VKnHXn3d5V2YrifZbmMY8os7M6m8wdYFoO6w/fe5VkP+YVwrEktW3IWYaSQVNZJ8oQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.1.4",
@@ -2408,7 +3323,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
       "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2421,7 +3335,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.5.tgz",
       "integrity": "sha512-N40PfqsZHRSsByGB81HhSo+uvMxEHT+9e255S53pfBw/wI6WKDI7Jw9oyu5tJTLwZzV5DsMha3ji8jk9dsHmQQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.3.2",
@@ -2435,7 +3348,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.7.tgz",
       "integrity": "sha512-TTO6rt0ppK70alZpkjwy+3nQlTiqNfoXja+qwuAchIEAIoSZW8Qyd76dvBv3I5bCpE38APafG23Y/u270NspiQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^4.0.7",
@@ -2450,7 +3362,6 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.4.tgz",
       "integrity": "sha512-vSKnvNZX2BXzl0U2RgCLOwWaAP9x/ddd/XobPK02pCbzRm5s55M53uwb1rl/Ts7RXZvdJZerPkA+en2FDghLuQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.1.1",
@@ -2470,7 +3381,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
       "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2483,7 +3393,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
       "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.0.0",
@@ -2497,7 +3406,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.7.tgz",
       "integrity": "sha512-mYqtQXPmrwvUljaHyGxYUIIRI3qjBTEb/f5QFi3A6VlxhpmZd5mWXn9W+qUkf2pVE1Hv3SqxefiZOPGdxmO64A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.0.5",
@@ -2620,7 +3528,6 @@
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/warning": {
@@ -2802,7 +3709,6 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.0.tgz",
       "integrity": "sha512-HcOcTudTeEWgbHh0Y1Tyb6fdeR71m4b/QACf0D4KswGTsNeIJQmg38mRENZPAYPZvGFN3fk3604XbQEPdxXdKg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/buffer-equal-constant-time": {
@@ -3359,7 +4265,6 @@
       "version": "5.2.5",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
       "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4687,7 +5592,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
       "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "test:e2e": "vitest run tests/e2e/*.test.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.873.0",
+    "@aws-sdk/s3-request-presigner": "^3.873.0",
     "@prisma/client": "^6.14.0",
     "@prisma/extension-accelerate": "^2.0.2",
     "bcryptjs": "^2.4.3",

--- a/src/app/api/candidate/settings.ts
+++ b/src/app/api/candidate/settings.ts
@@ -1,0 +1,32 @@
+import { prisma } from "../../../../lib/db";
+import { s3 } from "../../../../lib/s3";
+import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+export async function getCandidateSettings(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    include: { candidateProfile: true },
+  });
+
+  if (!user) return null;
+
+  let resumeUrl = user.candidateProfile?.resumeUrl ?? null;
+  if (resumeUrl && process.env.AWS_S3_BUCKET) {
+    try {
+      const command = new GetObjectCommand({
+        Bucket: process.env.AWS_S3_BUCKET!,
+        Key: resumeUrl,
+      });
+      resumeUrl = await getSignedUrl(s3, command, { expiresIn: 3600 });
+    } catch {
+      // ignore S3 errors and fall back to stored URL
+    }
+  }
+
+  return {
+    email: user.email,
+    resumeUrl,
+  };
+}
+

--- a/src/app/candidate/settings/page.tsx
+++ b/src/app/candidate/settings/page.tsx
@@ -1,16 +1,28 @@
 import { Card, Button, Input } from "../../../components/ui";
+import { auth } from "../../../../auth";
+import { getCandidateSettings } from "../../../app/api/candidate/settings";
+import ResumePreview from "../../../components/ResumePreview";
 
-export default function CandidateSettings(){
+export default async function CandidateSettings() {
+  const session = await auth();
+  const data = session?.user ? await getCandidateSettings(session.user.id) : null;
+
   return (
       <div className="grid grid-2">
         <Card className="col" style={{padding:16}}>
           <h3>Account</h3>
           <label>Name</label>
-          <Input defaultValue="Morty Smith"/>
+          <Input defaultValue={session?.user?.name ?? ""}/>
           <label>Email</label>
-          <Input defaultValue="morty.smith@columbia.edu"/>
+          <Input defaultValue={data?.email ?? ""}/>
           <label>Resume Upload</label>
           <Input type="file"/>
+          {data?.resumeUrl && (
+            <>
+              <a href={data.resumeUrl} target="_blank" rel="noopener noreferrer">Download Current Resume</a>
+              <ResumePreview url={data.resumeUrl} />
+            </>
+          )}
           <label>Password</label>
           <Input type="password" defaultValue="***************"/>
           <div className="row" style={{gap:8, marginTop:12}}>

--- a/src/components/ResumePreview.tsx
+++ b/src/components/ResumePreview.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+interface ResumePreviewProps {
+  url: string;
+}
+
+export default function ResumePreview({ url }: ResumePreviewProps) {
+  return (
+    <iframe
+      src={url}
+      style={{ width: '100%', height: '600px', border: 'none', marginTop: 8 }}
+      title="Resume preview"
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- preview uploaded resumes directly on the candidate settings page
- clarify required AWS S3 environment variables for resume access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad21a07c7c8325a3574e8dd43d74a7