### PR TITLE
feat: add pagination to user listing

### DIFF
--- a/src/app/api/users/list.ts
+++ b/src/app/api/users/list.ts
@@ -1,14 +1,32 @@
 import { prisma } from "../../../../lib/db";
 import { Role } from "@prisma/client";
 
-export async function listUsers(roles: Role[] = [Role.PROFESSIONAL]) {
-  return prisma.user.findMany({
-    where: { role: { in: roles } },
-    include: {
-      professionalProfile: true,
-      candidateProfile: true,
-      bookingsAsProfessional: true,
-      bookingsAsCandidate: true,
-    },
-  });
+export async function listUsers(
+  roles: Role[] = [Role.PROFESSIONAL],
+  page = 1,
+  perPage = 10
+) {
+  const skip = (page - 1) * perPage;
+
+  const [users, total] = await Promise.all([
+    prisma.user.findMany({
+      where: { role: { in: roles } },
+      include: {
+        professionalProfile: true,
+        candidateProfile: true,
+        bookingsAsProfessional: true,
+        bookingsAsCandidate: true,
+      },
+      skip,
+      take: perPage,
+    }),
+    prisma.user.count({ where: { role: { in: roles } } }),
+  ]);
+
+  return {
+    users,
+    page,
+    total,
+    totalPages: Math.ceil(total / perPage),
+  };
 }

--- a/src/app/candidate/browse/page.tsx
+++ b/src/app/candidate/browse/page.tsx
@@ -43,7 +43,7 @@ export default async function Browse() {
   const [filterOptions, results] = await Promise.all([
     getFilterOptions(filterConfig),
     // By default, only show professionals. Pass [Role.CANDIDATE] or both to customize.
-    listUsers([Role.PROFESSIONAL]),
+    listUsers([Role.PROFESSIONAL], 1, 50).then((result) => result.users),
   ]);
   const availabilityTransform = filterConfig["Availability"].transform!;
 

--- a/src/app/candidate/dashboard/page.tsx
+++ b/src/app/candidate/dashboard/page.tsx
@@ -52,7 +52,7 @@ export default async function CandidateDashboard() {
   const [filterOptions, results, upcomingCalls] = await Promise.all([
     getFilterOptions(filterConfig),
     // Default to professionals only; adjust roles as needed.
-    listUsers([Role.PROFESSIONAL]),
+    listUsers([Role.PROFESSIONAL], 1, 50).then((result) => result.users),
     upcomingCallsPromise,
   ]);
 


### PR DESCRIPTION
## Summary
- paginate user listing and default to 10 results per page
- load only first 50 professionals on candidate dashboard
- use same limited list on candidate browse

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aea01c83888325ac8a987d115e6adc