### PR TITLE
Enable OAuth sign-up and add profile onboarding step

### DIFF
--- a/src/app/(public)/signup/SignUpForm.tsx
+++ b/src/app/(public)/signup/SignUpForm.tsx
@@ -23,7 +23,11 @@ export default function SignUpForm() {
     });
     setLoading(false);
     if (res.ok) {
-      await signIn('credentials', { email, password, callbackUrl: role === 'PROFESSIONAL' ? '/professional/dashboard' : '/candidate/dashboard' });
+      await signIn('credentials', {
+        email,
+        password,
+        callbackUrl: '/signup/details',
+      });
     } else {
       const data = await res.json().catch(() => null);
       setError(data?.error || 'Failed to sign up');
@@ -46,8 +50,28 @@ export default function SignUpForm() {
       <Input name="password" type="password" placeholder="Password" required />
       {error && <p style={{ color: 'red' }}>{error}</p>}
       <Button type="submit" disabled={loading}>Create Account</Button>
-      <Button type="button" onClick={() => signIn('google', { callbackUrl: role === 'PROFESSIONAL' ? '/professional/dashboard' : '/candidate/dashboard' })} variant="muted" disabled={!role}>Sign up with Google</Button>
-      <Button type="button" onClick={() => signIn('linkedin', { callbackUrl: role === 'PROFESSIONAL' ? '/professional/dashboard' : '/candidate/dashboard' })} variant="muted" disabled={!role}>Sign up with LinkedIn</Button>
+      <Button
+        type="button"
+        onClick={() =>
+          signIn('google', {
+            callbackUrl: role ? `/signup/details?role=${role}` : '/signup/details',
+          })
+        }
+        variant="muted"
+      >
+        Sign up with Google
+      </Button>
+      <Button
+        type="button"
+        onClick={() =>
+          signIn('linkedin', {
+            callbackUrl: role ? `/signup/details?role=${role}` : '/signup/details',
+          })
+        }
+        variant="muted"
+      >
+        Sign up with LinkedIn
+      </Button>
     </form>
   );
 }

--- a/src/app/(public)/signup/details/DetailsForm.tsx
+++ b/src/app/(public)/signup/details/DetailsForm.tsx
@@ -1,0 +1,71 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input, Button, Select } from '../../../../components/ui';
+
+export default function DetailsForm({ initialRole }: { initialRole: 'CANDIDATE' | 'PROFESSIONAL' }) {
+  const [role, setRole] = useState<'CANDIDATE' | 'PROFESSIONAL'>(initialRole);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const body: any = { role };
+    if (role === 'CANDIDATE') {
+      body.resumeUrl = formData.get('resumeUrl') || undefined;
+      body.interests = formData.get('interests') || '';
+      body.activities = formData.get('activities') || '';
+    } else {
+      body.employer = formData.get('employer');
+      body.title = formData.get('title');
+      body.seniority = formData.get('seniority');
+      body.bio = formData.get('bio');
+      body.priceUSD = Number(formData.get('priceUSD'));
+    }
+    setLoading(true);
+    const res = await fetch('/api/onboarding', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    setLoading(false);
+    if (res.ok) {
+      router.push(role === 'PROFESSIONAL' ? '/professional/dashboard' : '/candidate/dashboard');
+    } else {
+      const data = await res.json().catch(() => null);
+      setError(data?.error || 'Failed to save profile');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="col" style={{ gap: 12 }}>
+      <Select value={role} onChange={(e) => setRole(e.target.value as 'CANDIDATE' | 'PROFESSIONAL')}>
+        <option value="CANDIDATE">Candidate</option>
+        <option value="PROFESSIONAL">Professional</option>
+      </Select>
+
+      {role === 'CANDIDATE' ? (
+        <>
+          <Input name="resumeUrl" placeholder="Resume URL" />
+          <Input name="interests" placeholder="Interests (comma separated)" />
+          <Input name="activities" placeholder="Activities (comma separated)" />
+        </>
+      ) : (
+        <>
+          <Input name="employer" placeholder="Employer" required />
+          <Input name="title" placeholder="Title" required />
+          <Input name="seniority" placeholder="Seniority" required />
+          <textarea name="bio" placeholder="Bio" className="input" required />
+          <Input name="priceUSD" type="number" placeholder="Price USD" required />
+        </>
+      )}
+
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <Button type="submit" disabled={loading}>Continue</Button>
+    </form>
+  );
+}
+

--- a/src/app/(public)/signup/details/page.tsx
+++ b/src/app/(public)/signup/details/page.tsx
@@ -1,0 +1,39 @@
+import { redirect } from 'next/navigation';
+import { auth } from '../../../../../auth';
+import { prisma } from '../../../../../lib/db';
+import { Card } from '../../../../components/ui';
+import DetailsForm from './DetailsForm';
+
+export default async function SignUpDetailsPage({
+  searchParams,
+}: {
+  searchParams: { role?: string };
+}) {
+  const session = await auth();
+  if (!session?.user) {
+    redirect('/login');
+  }
+  const user = await prisma.user.findUnique({
+    where: { id: session.user.id },
+    include: { candidateProfile: true, professionalProfile: true },
+  });
+  if (user?.candidateProfile || user?.professionalProfile) {
+    redirect(
+      session.user.role === 'PROFESSIONAL'
+        ? '/professional/dashboard'
+        : '/candidate/dashboard'
+    );
+  }
+  const initialRole =
+    searchParams.role === 'PROFESSIONAL' || searchParams.role === 'CANDIDATE'
+      ? (searchParams.role as 'CANDIDATE' | 'PROFESSIONAL')
+      : (session.user.role as 'CANDIDATE' | 'PROFESSIONAL');
+
+  return (
+    <Card style={{ maxWidth: 500, margin: '40px auto', padding: 24 }}>
+      <h1>Complete Your Profile</h1>
+      <DetailsForm initialRole={initialRole} />
+    </Card>
+  );
+}
+

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '../../../../auth';
+import { prisma } from '../../../../lib/db';
+import { z } from 'zod';
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const body = await req.json().catch(() => null);
+  const base = z.object({ role: z.enum(['CANDIDATE', 'PROFESSIONAL']) });
+  const parsedBase = base.safeParse(body);
+  if (!parsedBase.success) {
+    return NextResponse.json({ error: 'invalid_body' }, { status: 400 });
+  }
+  const { role } = parsedBase.data;
+  if (role === 'CANDIDATE') {
+    const schema = base.extend({
+      resumeUrl: z.string().url().optional(),
+      interests: z.string().optional(),
+      activities: z.string().optional(),
+    });
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'invalid_body' }, { status: 400 });
+    }
+    const { resumeUrl, interests, activities } = parsed.data;
+    await prisma.user.update({
+      where: { id: session.user.id },
+      data: { role },
+    });
+    await prisma.candidateProfile.upsert({
+      where: { userId: session.user.id },
+      update: {
+        resumeUrl: resumeUrl || undefined,
+        interests: interests ? interests.split(',').map((s) => s.trim()) : [],
+        activities: activities ? activities.split(',').map((s) => s.trim()) : [],
+      },
+      create: {
+        userId: session.user.id,
+        resumeUrl: resumeUrl || undefined,
+        interests: interests ? interests.split(',').map((s) => s.trim()) : [],
+        activities: activities ? activities.split(',').map((s) => s.trim()) : [],
+      },
+    });
+  } else {
+    const schema = base.extend({
+      employer: z.string(),
+      title: z.string(),
+      seniority: z.string(),
+      bio: z.string(),
+      priceUSD: z.number(),
+    });
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'invalid_body' }, { status: 400 });
+    }
+    const { employer, title, seniority, bio, priceUSD } = parsed.data;
+    await prisma.user.update({
+      where: { id: session.user.id },
+      data: { role },
+    });
+    await prisma.professionalProfile.upsert({
+      where: { userId: session.user.id },
+      update: {
+        employer,
+        title,
+        seniority,
+        bio,
+        priceUSD,
+      },
+      create: {
+        userId: session.user.id,
+        employer,
+        title,
+        seniority,
+        bio,
+        priceUSD,
+      },
+    });
+  }
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
## Summary
- Activate Google and LinkedIn signup buttons
- Introduce profile completion page to gather candidate or professional details
- Persist onboarding data via new API endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afb07e80ac8325b0aef10a359f0e50