### PR TITLE
Automatically sync candidate busy times

### DIFF
--- a/src/components/AvailabilityCalendar.tsx
+++ b/src/components/AvailabilityCalendar.tsx
@@ -12,15 +12,6 @@ export default function AvailabilityCalendar(){
   const [events, setEvents] = useState<Slot[]>([]);
   const [busyEvents, setBusyEvents] = useState<Slot[]>([]);
 
-  useEffect(() => {
-    const saved = localStorage.getItem('candidateAvailability');
-    if(saved) setEvents(JSON.parse(saved));
-  }, []);
-
-  useEffect(() => {
-    localStorage.setItem('candidateAvailability', JSON.stringify(events));
-  }, [events]);
-
   const handleSync = async () => {
     const res = await fetch('/api/candidate/busy');
     if(!res.ok) return;
@@ -31,6 +22,19 @@ export default function AvailabilityCalendar(){
     }));
     setBusyEvents(fetched);
   };
+
+  useEffect(() => {
+    const saved = localStorage.getItem('candidateAvailability');
+    if(saved) setEvents(JSON.parse(saved));
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('candidateAvailability', JSON.stringify(events));
+  }, [events]);
+
+  useEffect(() => {
+    handleSync();
+  }, []);
 
   const start = startOfWeek(new Date(), { weekStartsOn: 0 });
   const days = Array.from({ length: 7 }, (_, i) => addDays(start, i));


### PR DESCRIPTION
## Summary
- Automatically sync candidate busy times from `/api/candidate/busy` when the availability calendar mounts
- Retain manual button to refresh Google Calendar availability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b16082a8b88325a840da04c801416d