### PR TITLE
Fix OAuth sign-in redirects on login and signup

### DIFF
--- a/src/app/(public)/login/LoginForm.tsx
+++ b/src/app/(public)/login/LoginForm.tsx
@@ -5,32 +5,78 @@ import { Input, Button } from '../../../components/ui';
 
 export default function LoginForm() {
   const [error, setError] = useState<string | null>(null);
+  const [email, setEmail] = useState('');
+
+  async function getCallbackUrl(email: string) {
+    if (!email) return '/candidate/dashboard';
+    try {
+      const res = await fetch(`/api/auth/role?email=${encodeURIComponent(email)}`);
+      if (!res.ok) return '/candidate/dashboard';
+      const data = await res.json();
+      return data.role === 'PROFESSIONAL'
+        ? '/professional/dashboard'
+        : '/candidate/dashboard';
+    } catch {
+      return '/candidate/dashboard';
+    }
+  }
+
+  async function handleOAuth(provider: 'google' | 'linkedin') {
+    const callbackUrl = await getCallbackUrl(email);
+    const res = await signIn(provider, {
+      callbackUrl,
+      redirect: false,
+    });
+    if (res?.url) window.location.href = res.url;
+  }
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError(null);
     const form = e.currentTarget;
-    const email = (form.elements.namedItem('email') as HTMLInputElement).value;
+    const emailVal = (form.elements.namedItem('email') as HTMLInputElement).value;
     const password = (form.elements.namedItem('password') as HTMLInputElement).value;
+    const callbackUrl = await getCallbackUrl(emailVal);
     const res: SignInResponse | undefined = await signIn('credentials', {
-      email,
+      email: emailVal,
       password,
-      callbackUrl: '/candidate/dashboard',
+      callbackUrl,
       redirect: false,
     });
     if (res?.error) {
       setError('Invalid credentials');
+    } else if (res?.url) {
+      window.location.href = res.url;
     }
   }
 
   return (
     <form onSubmit={handleSubmit} className="col" style={{ gap: 12 }}>
-      <Input name="email" type="email" placeholder="Email" required />
+      <Input
+        name="email"
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
       <Input name="password" type="password" placeholder="Password" required />
       {error && <p style={{ color: 'red' }}>{error}</p>}
       <Button type="submit">Log In</Button>
-      <Button type="button" onClick={() => signIn('google')} variant="muted">Log in with Google</Button>
-      <Button type="button" onClick={() => signIn('linkedin')} variant="muted">Log in with LinkedIn</Button>
+      <Button
+        type="button"
+        onClick={() => void handleOAuth('google')}
+        variant="muted"
+      >
+        Log in with Google
+      </Button>
+      <Button
+        type="button"
+        onClick={() => void handleOAuth('linkedin')}
+        variant="muted"
+      >
+        Log in with LinkedIn
+      </Button>
     </form>
   );
 }

--- a/src/app/(public)/signup/SignUpForm.tsx
+++ b/src/app/(public)/signup/SignUpForm.tsx
@@ -8,6 +8,12 @@ export default function SignUpForm() {
   const [loading, setLoading] = useState(false);
   const [role, setRole] = useState<'CANDIDATE' | 'PROFESSIONAL' | ''>('');
 
+  async function handleOAuth(provider: 'google' | 'linkedin') {
+    const callbackUrl = role ? `/signup/details?role=${role}` : '/signup/details';
+    const res = await signIn(provider, { callbackUrl, redirect: false });
+    if (res?.url) window.location.href = res.url;
+  }
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
     setError(null);
@@ -52,22 +58,14 @@ export default function SignUpForm() {
       <Button type="submit" disabled={loading}>Create Account</Button>
       <Button
         type="button"
-        onClick={() =>
-          signIn('google', {
-            callbackUrl: role ? `/signup/details?role=${role}` : '/signup/details',
-          })
-        }
+        onClick={() => handleOAuth('google')}
         variant="muted"
       >
         Sign up with Google
       </Button>
       <Button
         type="button"
-        onClick={() =>
-          signIn('linkedin', {
-            callbackUrl: role ? `/signup/details?role=${role}` : '/signup/details',
-          })
-        }
+        onClick={() => handleOAuth('linkedin')}
         variant="muted"
       >
         Sign up with LinkedIn

--- a/src/app/api/auth/role/route.ts
+++ b/src/app/api/auth/role/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../../../lib/db';
+import { z } from 'zod';
+
+export async function GET(req: NextRequest) {
+  const email = req.nextUrl.searchParams.get('email');
+  const schema = z.object({ email: z.string().email() });
+  const parsed = schema.safeParse({ email });
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'invalid_email' }, { status: 400 });
+  }
+  const user = await prisma.user.findUnique({
+    where: { email: parsed.data.email },
+    select: { role: true }
+  });
+  return NextResponse.json({ role: user?.role ?? null });
+}


### PR DESCRIPTION
## Summary
- add API route to look up user role by email
- compute login callback URL based on user role so OAuth and credential sign-ins reach the correct dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b16b1d52a083259383efb2e9a22d7b