### PR TITLE
fix: unify date formatting to avoid hydration mismatch

### DIFF
--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,5 @@
+import { format } from 'date-fns';
+
+export function formatDateTime(input: Date | string) {
+  return format(new Date(input), 'yyyy-MM-dd HH:mm:ss');
+}

--- a/src/app/candidate/history/page.tsx
+++ b/src/app/candidate/history/page.tsx
@@ -1,6 +1,7 @@
 import { auth } from "../../../../auth";
 import DashboardClient from "../../../components/DashboardClient";
 import { getPastCalls } from "../../../app/api/bookings/history";
+import { formatDateTime } from "../../../../lib/date";
 
 export default async function History() {
   const session = await auth();
@@ -10,7 +11,7 @@ export default async function History() {
     title: c.professional.professionalProfile
       ? `${c.professional.professionalProfile.title} at ${c.professional.professionalProfile.employer}`
       : c.professional.email,
-    date: new Date(c.startAt).toLocaleString(),
+    date: formatDateTime(c.startAt),
     action: { label: "View Feedback", href: "#" },
   }));
 

--- a/src/components/UpcomingCalls.tsx
+++ b/src/components/UpcomingCalls.tsx
@@ -2,6 +2,7 @@
 
 import { Card, Button } from './ui';
 import React from 'react';
+import { formatDateTime } from '../../lib/date';
 
 interface Call {
   id: string;
@@ -32,7 +33,7 @@ export default function UpcomingCalls({ calls }: { calls: Call[] }) {
                 {c.professional.professionalProfile?.title ?? ''}
               </span>
               <span style={{ color: 'var(--text-muted)' }}>
-                {new Date(c.startAt).toLocaleString()}
+                {formatDateTime(c.startAt)}
               </span>
             </div>
             <Button


### PR DESCRIPTION
## Summary
- add shared `formatDateTime` helper
- use helper for candidate history and upcoming calls to ensure consistent rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21bed5ccc8325a2666347bf6638f2