### PR TITLE
fix: prevent setState in parent during FilterDropdown render

### DIFF
--- a/src/components/FilterDropdown.tsx
+++ b/src/components/FilterDropdown.tsx
@@ -46,21 +46,17 @@ function FilterDropdownComponent({
   }, []);
 
   const toggleOption = (opt: string) => {
-    setSelected((prev) => {
-      const next = prev.includes(opt)
-        ? prev.filter((o) => o !== opt)
-        : [...prev, opt];
-      onChange?.(next);
-      return next;
-    });
+    const next = selected.includes(opt)
+      ? selected.filter((o) => o !== opt)
+      : [...selected, opt];
+    setSelected(next);
+    onChange?.(next);
   };
 
   const toggleAll = () => {
-    setSelected((prev) => {
-      const next = prev.length === options.length ? [] : options;
-      onChange?.(next);
-      return next;
-    });
+    const next = selected.length === options.length ? [] : options;
+    setSelected(next);
+    onChange?.(next);
   };
 
   const filtered = options.filter((o) =>


### PR DESCRIPTION
## Summary
- avoid calling parent state update inside FilterDropdown render path to eliminate React warning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b21d83f3a4832588442776637adf1f