### PR TITLE
feat: enhance availability scheduling

### DIFF
--- a/lib/calendar/google.ts
+++ b/lib/calendar/google.ts
@@ -14,12 +14,13 @@ export async function getBusyTimes(userId: string){
   oauth2.setCredentials({ access_token: acc.accessToken, refresh_token: acc.refreshToken || undefined });
   const cal = google.calendar({ version: 'v3', auth: oauth2 });
   const now = new Date();
-  const nextWeek = new Date(now.getTime() + 7*24*60*60*1000);
+  const nextMonth = new Date(now);
+  nextMonth.setMonth(now.getMonth() + 1);
   try{
     const res = await cal.freebusy.query({
       requestBody: {
         timeMin: now.toISOString(),
-        timeMax: nextWeek.toISOString(),
+        timeMax: nextMonth.toISOString(),
         items: [{ id: 'primary' }]
       }
     });

--- a/prisma/migrations/20241014000000_add_availability/migration.sql
+++ b/prisma/migrations/20241014000000_add_availability/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "Availability" (
+  "id" TEXT PRIMARY KEY DEFAULT gen_random_uuid(),
+  "userId" TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "start" TIMESTAMP NOT NULL,
+  "end" TIMESTAMP NOT NULL,
+  "busy" BOOLEAN NOT NULL DEFAULT false
+);
+
+-- CreateIndex
+CREATE INDEX "Availability_userId_start_idx" ON "Availability"("userId","start");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -67,6 +67,7 @@ model User {
   bookingsAsProfessional Booking[]            @relation("ProfessionalBookings")
   notifications          Notification[]
   auditLogs              AuditLog[]           @relation("AuditActor")
+  availabilities         Availability[]
 
   @@index([role])
 }
@@ -243,6 +244,18 @@ model Notification {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([scheduledFor])
+}
+
+model Availability {
+  id     String   @id @default(cuid())
+  userId String
+  start  DateTime
+  end    DateTime
+  busy   Boolean  @default(false)
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId, start])
 }
 
 model AuditLog {

--- a/src/app/api/candidate/availability/route.ts
+++ b/src/app/api/candidate/availability/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { auth } from '../../../../../auth';
+import { prisma } from '../../../../../lib/db';
+
+export async function POST(req: Request){
+  const session = await auth();
+  if(!session?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const { events = [], busy = [] } = await req.json();
+
+  await prisma.availability.deleteMany({ where: { userId: session.user.id } });
+  const data = [
+    ...events.map((e: any) => ({ userId: session.user.id, start: e.start, end: e.end, busy: false })),
+    ...busy.map((e: any) => ({ userId: session.user.id, start: e.start, end: e.end, busy: true })),
+  ];
+  if(data.length) await prisma.availability.createMany({ data });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/candidate/availability/page.tsx
+++ b/src/app/candidate/availability/page.tsx
@@ -1,14 +1,26 @@
 'use client';
-import React from 'react';
-import AvailabilityCalendar from '../../../components/AvailabilityCalendar';
+import React, { useRef } from 'react';
+import AvailabilityCalendar, { AvailabilityCalendarRef } from '../../../components/AvailabilityCalendar';
 import { Button } from '../../../components/ui';
 
 export default function Availability(){
+  const calRef = useRef<AvailabilityCalendarRef>(null);
+
+  const handleConfirm = async () => {
+    const data = calRef.current?.getData();
+    if(!data) return;
+    await fetch('/api/candidate/availability', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  };
+
   return (
     <div className="col" style={{ gap: 16 }}>
-      <AvailabilityCalendar />
+      <AvailabilityCalendar ref={calRef} />
       <div className="row" style={{ justifyContent: 'flex-end' }}>
-        <Button>Confirm Availability</Button>
+        <Button onClick={handleConfirm}>Confirm Availability</Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show month on calendar headers and add week navigation controls
- sync Google Calendar one month ahead by default
- persist confirmed availability slots via new API and Prisma model

## Testing
- `npx prisma generate`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b221ad6f448325842f0e4f278be414