### PR TITLE
Add Stripe Connect onboarding to professional settings

### DIFF
--- a/src/app/api/stripe/account/route.ts
+++ b/src/app/api/stripe/account/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '../../../../../auth';
+import { prisma } from '../../../../../lib/db';
+import {
+  stripe,
+  ensureConnectedAccount,
+  createAccountOnboardingLink,
+} from '../../../../../lib/payments/stripe';
+
+export async function GET(_req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({ where: { id: session.user.id } });
+  if (!user?.stripeAccountId) {
+    return NextResponse.json({ status: 'not_connected' });
+  }
+
+  try {
+    const account = await stripe.accounts.retrieve(user.stripeAccountId);
+    const status = account.charges_enabled && account.payouts_enabled
+      ? 'complete'
+      : account.details_submitted
+      ? 'pending'
+      : 'incomplete';
+    return NextResponse.json({
+      status,
+      detailsSubmitted: account.details_submitted,
+      chargesEnabled: account.charges_enabled,
+      payoutsEnabled: account.payouts_enabled,
+    });
+  } catch (e) {
+    return NextResponse.json({ error: 'stripe_error' }, { status: 500 });
+  }
+}
+
+export async function POST(_req: NextRequest) {
+  const session = await auth();
+  if (!session?.user) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({ where: { id: session.user.id } });
+  if (!user) {
+    return NextResponse.json({ error: 'user_not_found' }, { status: 404 });
+  }
+
+  try {
+    const accountId = await ensureConnectedAccount(
+      session.user.id,
+      session.user.email || '',
+      user.firstName || '',
+      user.lastName || '',
+    );
+    const baseUrl = process.env.APP_URL || 'http://localhost:3000';
+    const onboardingUrl = await createAccountOnboardingLink(
+      accountId,
+      `${baseUrl}/professional/settings`,
+      `${baseUrl}/professional/settings`,
+    );
+    return NextResponse.json({ onboardingUrl });
+  } catch (e) {
+    return NextResponse.json({ error: 'stripe_error' }, { status: 500 });
+  }
+}
+

--- a/src/app/professional/settings/page.tsx
+++ b/src/app/professional/settings/page.tsx
@@ -1,31 +1,94 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import { Card, Button, Input } from "../../../components/ui";
 
-export default function ProSettings(){
-  return (
-      <Card style={{padding:16}}>
-        <h2>Settings</h2>
-        <div className="grid grid-2">
-          <div className="col" style={{gap:12}}>
-            <h3>Profile</h3>
-            <label>Full name</label>
-            <Input defaultValue="First Last"/>
-            <label>Email</label>
-            <Input defaultValue="pro1@monet.local"/>
-            <label>Timezone</label>
-            <Input defaultValue="America/New_York"/>
+export default function ProSettings() {
+  const [status, setStatus] = useState("loading");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
-            <h3>Calendar</h3>
-            <p>Connect your calendar to automatically block out busy times.</p>
-            <Button>Connect Calendar</Button>
-          </div>
-          <div className="col" style={{gap:12}}>
-            <h3>Payment</h3>
-            <p>Onboard to Stripe Connect to receive payouts.</p>
-            <Button>Connect Stripe</Button>
-            <h3>Verification Status</h3>
-            <p>Corporate email not yet verified.</p>
-          </div>
+  useEffect(() => {
+    async function fetchStatus() {
+      try {
+        const res = await fetch("/api/stripe/account");
+        if (!res.ok) throw new Error();
+        const data = await res.json();
+        setStatus(data.status || "not_connected");
+      } catch {
+        setError("Failed to load Stripe status");
+      }
+    }
+    fetchStatus();
+  }, []);
+
+  const handleConnect = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/stripe/account", { method: "POST" });
+      const data = await res.json();
+      if (!res.ok || !data.onboardingUrl) throw new Error();
+      setMessage("Redirecting to Stripe...");
+      window.location.href = data.onboardingUrl;
+    } catch {
+      setError("Failed to start Stripe onboarding");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const statusLabel =
+    status === "complete"
+      ? "Connected"
+      : status === "pending"
+      ? "Pending verification"
+      : status === "incomplete"
+      ? "Incomplete"
+      : status === "loading"
+      ? "Loading..."
+      : "Not connected";
+
+  const canConnect =
+    status === "not_connected" || status === "incomplete";
+
+  return (
+    <Card style={{ padding: 16 }}>
+      <h2>Settings</h2>
+      <div className="grid grid-2">
+        <div className="col" style={{ gap: 12 }}>
+          <h3>Profile</h3>
+          <label>Full name</label>
+          <Input defaultValue="First Last" />
+          <label>Email</label>
+          <Input defaultValue="pro1@monet.local" />
+          <label>Timezone</label>
+          <Input defaultValue="America/New_York" />
+
+          <h3>Calendar</h3>
+          <p>Connect your calendar to automatically block out busy times.</p>
+          <Button>Connect Calendar</Button>
         </div>
-      </Card>
-  )
+        <div className="col" style={{ gap: 12 }}>
+          <h3>Payment</h3>
+          <p>Onboard to Stripe Connect to receive payouts.</p>
+          {canConnect && (
+            <Button onClick={handleConnect} disabled={loading}>
+              {loading
+                ? "Loading..."
+                : status === "incomplete"
+                ? "Resume Onboarding"
+                : "Connect Stripe"}
+            </Button>
+          )}
+          <p>Account status: {statusLabel}</p>
+          {error && <p style={{ color: "red" }}>{error}</p>}
+          {message && <p style={{ color: "green" }}>{message}</p>}
+          <h3>Verification Status</h3>
+          <p>Corporate email not yet verified.</p>
+        </div>
+      </div>
+    </Card>
+  );
 }


### PR DESCRIPTION
## Summary
- implement `/api/stripe/account` endpoint for account status and onboarding link generation
- enhance professional settings page with Stripe account status and onboarding link with loading & error states

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2463bc8d083258ead245c9648749e