### PR TITLE
Remove ProfessionalProfile seniority field

### DIFF
--- a/prisma/migrations/20240907000000_remove_seniority/migration.sql
+++ b/prisma/migrations/20240907000000_remove_seniority/migration.sql
@@ -1,0 +1,16 @@
+-- Drop existing view to allow column removal
+DROP VIEW IF EXISTS "ListingCardView";
+
+-- Remove seniority column from ProfessionalProfile
+ALTER TABLE "ProfessionalProfile" DROP COLUMN IF EXISTS "seniority";
+
+-- Drop associated index if it exists
+DROP INDEX IF EXISTS "ProfessionalProfile_seniority_idx";
+
+-- Recreate view without seniority column
+CREATE VIEW "ListingCardView" AS
+SELECT u.id as "userId", p.employer, p.title, p."priceUSD", ARRAY[]::text[] as tags
+FROM "User" u
+JOIN "ProfessionalProfile" p ON p."userId" = u.id
+WHERE u.role = 'PROFESSIONAL';
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,7 +93,6 @@ model ProfessionalProfile {
   userId            String       @id
   employer          String
   title             String
-  seniority         String
   bio               String
   priceUSD          Int
   availabilityPrefs Json         @default("{}")
@@ -107,7 +106,6 @@ model ProfessionalProfile {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([employer])
-  @@index([seniority])
   @@index([priceUSD])
 }
 
@@ -275,7 +273,6 @@ view ListingCardView {
   userId    String
   employer  String
   title     String
-  seniority String
   priceUSD  Int
   tags      String[]
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -169,7 +169,6 @@ async function createProfessionals() {
         userId: user.id,
         employer: pick(firms),
         title: pick(jobTitles),
-        seniority: pick(['Junior', 'Mid', 'Senior']),
         bio: 'Experienced finance professional with transaction and coverage background.',
         priceUSD: 80 + i,
         availabilityPrefs: {},

--- a/src/app/(public)/signup/details/DetailsForm.tsx
+++ b/src/app/(public)/signup/details/DetailsForm.tsx
@@ -25,7 +25,6 @@ export default function DetailsForm({ initialRole }: { initialRole: 'CANDIDATE' 
     } else {
       body.employer = formData.get('employer');
       body.title = formData.get('title');
-      body.seniority = formData.get('seniority');
       body.bio = formData.get('bio');
       body.priceUSD = Number(formData.get('priceUSD'));
     }
@@ -68,7 +67,6 @@ export default function DetailsForm({ initialRole }: { initialRole: 'CANDIDATE' 
         <>
           <Input name="employer" placeholder="Employer" required />
           <Input name="title" placeholder="Title" required />
-          <Input name="seniority" placeholder="Seniority" required />
           <textarea name="bio" placeholder="Bio" className="input" required />
           <Input name="priceUSD" type="number" placeholder="Price USD" required />
         </>

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -62,7 +62,6 @@ export async function POST(req: NextRequest) {
     const schema = base.extend({
       employer: z.string(),
       title: z.string(),
-      seniority: z.string(),
       bio: z.string(),
       priceUSD: z.number(),
     });
@@ -70,7 +69,7 @@ export async function POST(req: NextRequest) {
     if (!parsed.success) {
       return NextResponse.json({ error: 'invalid_body' }, { status: 400 });
     }
-    const { employer, title, seniority, bio, priceUSD } = parsed.data;
+    const { employer, title, bio, priceUSD } = parsed.data;
     await prisma.user.update({
       where: { id: session.user.id },
       data: { role, firstName, lastName },
@@ -80,7 +79,6 @@ export async function POST(req: NextRequest) {
       update: {
         employer,
         title,
-        seniority,
         bio,
         priceUSD,
       },
@@ -88,7 +86,6 @@ export async function POST(req: NextRequest) {
         userId: session.user.id,
         employer,
         title,
-        seniority,
         bio,
         priceUSD,
       },

--- a/src/app/api/professionals/[id]/route.ts
+++ b/src/app/api/professionals/[id]/route.ts
@@ -18,7 +18,6 @@ export async function GET(req: NextRequest, { params }:{params:{id:string}}){
   const payload: any = {
     employer: pro.employer,
     title: pro.title,
-    seniority: pro.seniority,
     priceUSD: pro.priceUSD,
     tags: [],
     verified: !!pro.verifiedAt,

--- a/src/app/api/professionals/search/route.ts
+++ b/src/app/api/professionals/search/route.ts
@@ -4,12 +4,10 @@ import { prisma } from '../../../../../lib/db';
 export async function GET(req: NextRequest){
   const url = new URL(req.url);
   const firm = url.searchParams.get('firm');
-  const seniority = url.searchParams.get('seniority');
   const priceMax = Number(url.searchParams.get('priceMax') || 1000);
   const pros = await prisma.professionalProfile.findMany({
     where: {
       employer: firm || undefined,
-      seniority: seniority || undefined,
       priceUSD: { lte: priceMax }
     },
     take: 50,
@@ -18,7 +16,6 @@ export async function GET(req: NextRequest){
     userId: p.userId,
     employer: p.employer,
     title: p.title,
-    seniority: p.seniority,
     priceUSD: p.priceUSD,
     tags: (p as any).tags || [],
   }));

--- a/src/app/candidate/browse/page.tsx
+++ b/src/app/candidate/browse/page.tsx
@@ -24,11 +24,6 @@ export default async function Browse({
       field: "employer",
       relation: "professionalProfile",
     },
-    "Experience Level": {
-      model: "professionalProfile",
-      field: "seniority",
-      relation: "professionalProfile",
-    },
     Availability: {
       model: "booking",
       field: "startAt",
@@ -70,7 +65,6 @@ export default async function Browse({
     name: { label: u.email, href: `/candidate/detail/${u.id}` },
     title: u.professionalProfile?.title ?? "",
     firm: u.professionalProfile?.employer ?? "",
-    experience: u.professionalProfile?.seniority ?? "",
     availability: availabilityTransform(
       u.bookingsAsProfessional.map((b) => b.startAt as Date)
     ),
@@ -80,7 +74,6 @@ export default async function Browse({
   const columns = [
     { key: "name", label: "Name" },
     { key: "title", label: "Title" },
-    { key: "experience", label: "Experience" },
     { key: "availability", label: "Availability" },
     { key: "action", label: "" },
   ];

--- a/src/app/candidate/dashboard/page.tsx
+++ b/src/app/candidate/dashboard/page.tsx
@@ -30,11 +30,6 @@ export default async function CandidateDashboard({
       field: "employer",
       relation: "professionalProfile",
     },
-    "Experience Level": {
-      model: "professionalProfile",
-      field: "seniority",
-      relation: "professionalProfile",
-    },
     Availability: {
       model: "booking",
       field: "startAt",
@@ -82,7 +77,6 @@ export default async function CandidateDashboard({
     name: { label: u.email, href: `/candidate/detail/${u.id}` },
     title: u.professionalProfile?.title ?? "",
     firm: u.professionalProfile?.employer ?? "",
-    experience: u.professionalProfile?.seniority ?? "",
     availability: availabilityTransform(
       u.bookingsAsProfessional.map((b) => b.startAt as Date)
     ),
@@ -92,7 +86,6 @@ export default async function CandidateDashboard({
   const columns = [
     { key: "name", label: "Name" },
     { key: "title", label: "Title" },
-    { key: "experience", label: "Experience" },
     { key: "availability", label: "Availability" },
     { key: "action", label: "" },
   ];

--- a/src/app/candidate/detail/[id]/page.tsx
+++ b/src/app/candidate/detail/[id]/page.tsx
@@ -5,7 +5,6 @@ interface ProfessionalResponse {
   identity: { name?: string; email?: string; redacted?: boolean };
   employer: string;
   title: string;
-  seniority: string;
   priceUSD: number;
   tags: string[];
   verified?: boolean;


### PR DESCRIPTION
## Summary
- drop redundant `seniority` column from `ProfessionalProfile`
- remove seniority from onboarding form and API
- update searches and dashboards to rely on `title` only

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b254b2f4d883258db4f770e04a46b3