### PR TITLE
Display firm name in upcoming calls and format date

### DIFF
--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
 
 export function formatDateTime(input: Date | string) {
-  return format(new Date(input), 'yyyy-MM-dd HH:mm:ss');
+  return format(new Date(input), 'MM/dd HH/mm');
 }

--- a/src/components/UpcomingCalls.tsx
+++ b/src/components/UpcomingCalls.tsx
@@ -12,6 +12,7 @@ interface Call {
     email: string;
     professionalProfile?: {
       title: string | null;
+      employer: string | null;
     } | null;
   };
 }
@@ -31,6 +32,9 @@ export default function UpcomingCalls({ calls }: { calls: Call[] }) {
               <strong>{c.professional.email}</strong>
               <span style={{ color: 'var(--text-muted)' }}>
                 {c.professional.professionalProfile?.title ?? ''}
+              </span>
+              <span style={{ color: 'var(--text-muted)' }}>
+                {c.professional.professionalProfile?.employer ?? ''}
               </span>
               <span style={{ color: 'var(--text-muted)' }}>
                 {formatDateTime(c.startAt)}


### PR DESCRIPTION
## Summary
- show professionals' firm names in upcoming calls
- format call times as `MM/dd HH/mm`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2acd7da0883258b5a7c6461a0e4d0