### PR TITLE
Refactor professional dashboard to reuse DashboardClient

### DIFF
--- a/src/app/professional/dashboard/page.tsx
+++ b/src/app/professional/dashboard/page.tsx
@@ -1,39 +1,63 @@
-import { Card, Button } from "../../../components/ui";
+import { Card } from "../../../components/ui";
+import DashboardClient from "../../../components/DashboardClient";
 
-export default function ProDashboard(){
+export default function ProDashboard() {
+  const rows = [
+    {
+      candidate: "Liam Carter",
+      date: "2024-03-15",
+      time: "10:00 AM",
+      action: { label: "Join" },
+    },
+    {
+      candidate: "Olivia Bennett",
+      date: "2024-03-16",
+      time: "11:30 AM",
+      action: { label: "Join" },
+    },
+    {
+      candidate: "Ethan Walker",
+      date: "2024-03-17",
+      time: "2:00 PM",
+      action: { label: "Join" },
+    },
+  ];
+
+  const columns = [
+    { key: "candidate", label: "Candidate" },
+    { key: "date", label: "Date" },
+    { key: "time", label: "Time" },
+    { key: "action", label: "" },
+  ];
+
   return (
-      <div className="grid grid-2">
-        <Card style={{padding:16}}>
-          <h3>Upcoming Calls</h3>
-          <table className="table">
-            <thead><tr><th>Candidate</th><th>Date</th><th>Time</th><th></th></tr></thead>
-            <tbody>
-              <tr><td>Liam Carter</td><td>2024-03-15</td><td>10:00 AM</td><td><Button>Join</Button></td></tr>
-              <tr><td>Olivia Bennett</td><td>2024-03-16</td><td>11:30 AM</td><td><Button>Join</Button></td></tr>
-              <tr><td>Ethan Walker</td><td>2024-03-17</td><td>2:00 PM</td><td><Button>Join</Button></td></tr>
-            </tbody>
-          </table>
-        </Card>
-        <Card style={{padding:16}}>
-          <div className="grid grid-2">
-            <div className="card" style={{padding:16}}>
-              <h4>Total Earnings</h4>
-              <div style={{fontSize:24}}>$2,500</div>
-            </div>
-            <div className="card" style={{padding:16}}>
-              <h4>Response Rate</h4>
-              <div style={{fontSize:24}}>85%</div>
-            </div>
-            <div className="card" style={{padding:16}}>
-              <h4>Recent Earnings</h4>
-              <div>$250 this month</div>
-            </div>
-            <div className="card" style={{padding:16}}>
-              <h4>Recent Feedback</h4>
-              <p>“Excellent insights and feedback on my case study.”</p>
-            </div>
+    <div className="grid grid-2">
+      <DashboardClient
+        data={rows}
+        columns={columns}
+        showFilters={false}
+        buttonColumns={["action"]}
+      />
+      <Card style={{ padding: 16 }}>
+        <div className="grid grid-2">
+          <div className="card" style={{ padding: 16 }}>
+            <h4>Total Earnings</h4>
+            <div style={{ fontSize: 24 }}>$2,500</div>
           </div>
-        </Card>
-      </div>
-  )
+          <div className="card" style={{ padding: 16 }}>
+            <h4>Response Rate</h4>
+            <div style={{ fontSize: 24 }}>85%</div>
+          </div>
+          <div className="card" style={{ padding: 16 }}>
+            <h4>Recent Earnings</h4>
+            <div>$250 this month</div>
+          </div>
+          <div className="card" style={{ padding: 16 }}>
+            <h4>Recent Feedback</h4>
+            <p>“Excellent insights and feedback on my case study.”</p>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- replace static table with reusable `DashboardClient` in professional dashboard
- disable filters for professional view while keeping quick stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ad0c5ab4832599bdae29d829179f