### PR TITLE
Fix seed script DateTime handling

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -24,8 +24,8 @@ const firms = [
 ];
 
 type TenorPeriod = { start: string; finish: string };
-type ExperienceEntry = { firm: string; title: string; startDate: string; endDate: string };
-type EducationEntry = { school: string; title: string; startDate: string; endDate: string };
+type ExperienceEntry = { firm: string; title: string; startDate: Date; endDate: Date };
+type EducationEntry = { school: string; title: string; startDate: Date; endDate: Date };
 
 const jobTitles = JOB_TITLES;
 const degreeTitles = DEGREE_TITLES;
@@ -53,8 +53,8 @@ const randomExperience = (): ExperienceEntry => {
   return {
     firm: pick(firms),
     title: pick(jobTitles),
-    startDate: period.start,
-    endDate: period.finish,
+    startDate: new Date(period.start),
+    endDate: new Date(period.finish),
   };
 };
 
@@ -63,8 +63,8 @@ const randomEducation = (): EducationEntry => {
   return {
     school: pick(schools),
     title: pick(degreeTitles),
-    startDate: period.start,
-    endDate: period.finish,
+    startDate: new Date(period.start),
+    endDate: new Date(period.finish),
   };
 };
 


### PR DESCRIPTION
## Summary
- use `Date` objects for experience and education seed data so Prisma accepts DateTime values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2afe246248325a490da8ee8c8384e