### PR TITLE
Add profile interests and experience tables

### DIFF
--- a/prisma/migrations/20250827000000_add_profile_extras/migration.sql
+++ b/prisma/migrations/20250827000000_add_profile_extras/migration.sql
@@ -1,0 +1,41 @@
+-- Add array fields to profiles and create experience/education tables
+
+-- CandidateProfile: add interests and activities, remove JSON fields
+ALTER TABLE "CandidateProfile"
+  ADD COLUMN "interests" TEXT[] DEFAULT ARRAY[]::TEXT[] NOT NULL,
+  ADD COLUMN "activities" TEXT[] DEFAULT ARRAY[]::TEXT[] NOT NULL;
+
+ALTER TABLE "CandidateProfile"
+  DROP COLUMN IF EXISTS "experience",
+  DROP COLUMN IF EXISTS "education";
+
+-- ProfessionalProfile: add interests and activities
+ALTER TABLE "ProfessionalProfile"
+  ADD COLUMN "interests" TEXT[] DEFAULT ARRAY[]::TEXT[] NOT NULL,
+  ADD COLUMN "activities" TEXT[] DEFAULT ARRAY[]::TEXT[] NOT NULL;
+
+-- Experience table
+CREATE TABLE "Experience" (
+  "id" TEXT PRIMARY KEY DEFAULT gen_random_uuid(),
+  "firm" TEXT NOT NULL,
+  "title" TEXT NOT NULL,
+  "startDate" TIMESTAMP NOT NULL,
+  "endDate" TIMESTAMP NOT NULL,
+  "professionalId" TEXT,
+  "candidateId" TEXT,
+  CONSTRAINT "Experience_professionalId_fkey" FOREIGN KEY ("professionalId") REFERENCES "ProfessionalProfile"("userId") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "Experience_candidateId_fkey" FOREIGN KEY ("candidateId") REFERENCES "CandidateProfile"("userId") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Education table
+CREATE TABLE "Education" (
+  "id" TEXT PRIMARY KEY DEFAULT gen_random_uuid(),
+  "school" TEXT NOT NULL,
+  "title" TEXT NOT NULL,
+  "startDate" TIMESTAMP NOT NULL,
+  "endDate" TIMESTAMP NOT NULL,
+  "professionalId" TEXT,
+  "candidateId" TEXT,
+  CONSTRAINT "Education_professionalId_fkey" FOREIGN KEY ("professionalId") REFERENCES "ProfessionalProfile"("userId") ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "Education_candidateId_fkey" FOREIGN KEY ("candidateId") REFERENCES "CandidateProfile"("userId") ON DELETE CASCADE ON UPDATE CASCADE
+);


### PR DESCRIPTION
## Summary
- add candidate and professional profile interests and activities arrays
- add Experience and Education tables for profile history

## Testing
- `npx prisma migrate reset --force` *(fails: Can't reach database server at monet3-instance-1.c254as8qcyac.us-east-1.rds.amazonaws.com:5432)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b30d49dc8325b760fa5e1c334944