### PR TITLE
Avoid selecting removed seniority field

### DIFF
--- a/src/app/(public)/signup/details/page.tsx
+++ b/src/app/(public)/signup/details/page.tsx
@@ -15,7 +15,10 @@ export default async function SignUpDetailsPage({
   }
   const user = await prisma.user.findUnique({
     where: { id: session.user.id },
-    include: { candidateProfile: true, professionalProfile: true },
+    select: {
+      candidateProfile: { select: { userId: true } },
+      professionalProfile: { select: { userId: true } },
+    },
   });
   if (user?.candidateProfile || user?.professionalProfile) {
     redirect(

--- a/src/app/api/bookings/history.ts
+++ b/src/app/api/bookings/history.ts
@@ -7,7 +7,14 @@ export async function getPastCalls(candidateId: string) {
       startAt: { lt: new Date() },
     },
     include: {
-      professional: { include: { professionalProfile: true } },
+      professional: {
+        select: {
+          email: true,
+          professionalProfile: {
+            select: { title: true, employer: true },
+          },
+        },
+      },
     },
     orderBy: { startAt: 'desc' },
   });

--- a/src/app/api/bookings/upcoming.ts
+++ b/src/app/api/bookings/upcoming.ts
@@ -7,7 +7,14 @@ export async function getUpcomingCalls(candidateId: string) {
       startAt: { gte: new Date() },
     },
     include: {
-      professional: { include: { professionalProfile: true } },
+      professional: {
+        select: {
+          email: true,
+          professionalProfile: {
+            select: { title: true, employer: true },
+          },
+        },
+      },
     },
     orderBy: { startAt: 'asc' },
   });

--- a/src/app/api/professional/settings.ts
+++ b/src/app/api/professional/settings.ts
@@ -3,7 +3,13 @@ import { prisma } from "../../../../lib/db";
 export async function getProfessionalSettings(userId: string) {
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    include: { professionalProfile: true },
+    select: {
+      email: true,
+      firstName: true,
+      lastName: true,
+      flags: true,
+      professionalProfile: { select: { verifiedAt: true } },
+    },
   });
   if (!user) return null;
 

--- a/src/app/api/users/list.ts
+++ b/src/app/api/users/list.ts
@@ -22,7 +22,22 @@ export async function listUsers(
     prisma.user.findMany({
       where,
       include: {
-        professionalProfile: true,
+        professionalProfile: {
+          select: {
+            userId: true,
+            employer: true,
+            title: true,
+            bio: true,
+            priceUSD: true,
+            availabilityPrefs: true,
+            verifiedAt: true,
+            corporateEmail: true,
+            experience: true,
+            education: true,
+            interests: true,
+            activities: true,
+          },
+        },
         candidateProfile: true,
         bookingsAsProfessional: true,
         bookingsAsCandidate: true,


### PR DESCRIPTION
## Summary
- Avoid selecting non-existent `ProfessionalProfile.seniority` by explicitly picking fields in Prisma queries
- Narrow professional profile data for user listings, booking lookups, professional settings, and signup flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2b6a258848325ba67d32d72c73017