### PR TITLE
Fix missing bookings in user listings

### DIFF
--- a/src/app/api/users/list.ts
+++ b/src/app/api/users/list.ts
@@ -21,17 +21,14 @@ export async function listUsers(
   const [users, total] = await Promise.all([
     prisma.user.findMany({
       where,
-      // include: {
-      //   professionalProfile: {
-      //     include: {
-      //       experience: true,
-      //       education: true
-      //     },
-      //   },
-      //   candidateProfile: true,
-      //   bookingsAsProfessional: true,
-      //   bookingsAsCandidate: true,
-      // },
+      include: {
+        professionalProfile: true,
+        bookingsAsProfessional: {
+          select: {
+            startAt: true,
+          },
+        },
+      },
       skip,
       take: perPage,
     }),


### PR DESCRIPTION
## Summary
- include `bookingsAsProfessional` and `professionalProfile` in user list query so candidate pages can compute availability without runtime errors

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run test:e2e` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b377f58ddc832585e180cfa0a13c90