### PR TITLE
Handle Google Calendar reauth

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -31,7 +31,7 @@ export const { handlers: { GET, POST }, auth, signIn, signOut } = NextAuth({
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID || '',
       clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
-      authorization: { params: { scope: 'openid email profile https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.events' } }
+      authorization: { params: { scope: 'openid email profile https://www.googleapis.com/auth/calendar.readonly https://www.googleapis.com/auth/calendar.events', access_type: 'offline', prompt: 'consent' } }
     }),
     LinkedIn({
       clientId: process.env.LINKEDIN_CLIENT_ID || '',

--- a/src/app/api/candidate/busy/route.ts
+++ b/src/app/api/candidate/busy/route.ts
@@ -5,6 +5,13 @@ import { getBusyTimes } from '../../../../../lib/calendar/google';
 export async function GET(){
   const session = await auth();
   if(!session?.user) return NextResponse.json({error:'unauthorized'},{status:401});
-  const busy = await getBusyTimes(session.user.id);
-  return NextResponse.json({ busy });
+  try{
+    const busy = await getBusyTimes(session.user.id);
+    return NextResponse.json({ busy });
+  }catch(err: any){
+    if(err.message === 'NOT_AUTHENTICATED'){
+      return NextResponse.json({ error: 'google_auth_required' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'failed_to_fetch' }, { status: 500 });
+  }
 }

--- a/src/components/AvailabilityCalendar.tsx
+++ b/src/components/AvailabilityCalendar.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState, forwardRef, useImperativeHandle } from 'react';
 import { Button } from './ui';
 import { addMinutes, addDays, startOfWeek, format } from 'date-fns';
+import { signIn } from 'next-auth/react';
 
 type Slot = {
   start: string;
@@ -19,6 +20,11 @@ const AvailabilityCalendar = forwardRef<AvailabilityCalendarRef>((_, ref) => {
 
   const handleSync = async () => {
     const res = await fetch('/api/candidate/busy');
+    if(res.status === 401){
+      alert('Please connect your Google Calendar to sync availability.');
+      await signIn('google', { callbackUrl: window.location.href });
+      return;
+    }
     if(!res.ok) return;
     const data = await res.json();
     const fetched: Slot[] = (data.busy || []).map((b: any) => ({


### PR DESCRIPTION
## Summary
- Throw explicit error when Google busy times cannot be retrieved
- Return 401 from busy API when re-authentication is required
- Prompt users to reconnect Google Calendar and redirect to OAuth flow
- Request offline access so Google refresh tokens can be stored

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3a0b4fb18832597f4766d44841558