### PR TITLE
Expose professional details and show pricing

### DIFF
--- a/src/app/api/professionals/[id]/route.ts
+++ b/src/app/api/professionals/[id]/route.ts
@@ -2,15 +2,25 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '../../../../../lib/db';
 import { auth } from '../../../../../auth';
 
-export async function GET(req: NextRequest, { params }:{params:{id:string}}){
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
   const session = await auth();
-  const pro = await prisma.professionalProfile.findUnique({ where: { userId: params.id } });
-  if(!pro) return NextResponse.json({error:'not_found'}, {status:404});
+  const pro = await prisma.professionalProfile.findUnique({
+    where: { userId: params.id },
+    include: { experience: true, education: true },
+  });
+  if (!pro) return NextResponse.json({ error: 'not_found' }, { status: 404 });
 
   let reveal = false;
-  if(session?.user){
+  if (session?.user) {
     const booked = await prisma.booking.findFirst({
-      where: { professionalId: params.id, candidateId: session.user.id, status: { in: ['accepted','completed','completed_pending_feedback'] } }
+      where: {
+        professionalId: params.id,
+        candidateId: session.user.id,
+        status: { in: ['accepted', 'completed', 'completed_pending_feedback'] },
+      },
     });
     reveal = !!booked;
   }
@@ -21,12 +31,27 @@ export async function GET(req: NextRequest, { params }:{params:{id:string}}){
     priceUSD: pro.priceUSD,
     tags: [],
     verified: !!pro.verifiedAt,
+    bio: pro.bio,
+    experience: pro.experience.map((e) => ({
+      role: e.role,
+      company: e.company,
+      period: e.period ?? undefined,
+    })),
+    education: pro.education.map((e) => ({
+      school: e.school,
+      degree: e.degree,
+      period: e.period ?? undefined,
+    })),
+    interests: pro.interests,
+    activities: pro.activities,
   };
-  if(reveal){
+
+  if (reveal) {
     payload.identity = { name: 'Revealed User', email: 'pro@example.com' };
-    payload.bio = pro.bio;
   } else {
     payload.identity = { redacted: true };
   }
+
   return NextResponse.json(payload);
 }
+

--- a/src/app/candidate/detail/[id]/page.tsx
+++ b/src/app/candidate/detail/[id]/page.tsx
@@ -48,6 +48,7 @@ export default async function Detail({ params }: { params: { id: string } }) {
           </div>
           <div className="col" style={{ gap: 4 }}>
             {name && <h2>{name}</h2>}
+            <span>{`$${pro.priceUSD}`}</span>
             <div className="row" style={{ alignItems: "center", gap: 8 }}>
               <span>{pro.title}</span>
               {pro.verified && <Badge>Verified Expert</Badge>}


### PR DESCRIPTION
## Summary
- expand professional profile API to return bio, experience, education, interests and activities
- show professional's hourly price under their name on candidate detail page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3dd2a7d348325b1a694accc0f02dd