### PR TITLE
feat: add candidate feedback detail page

### DIFF
--- a/src/app/api/feedback/[bookingId]/route.ts
+++ b/src/app/api/feedback/[bookingId]/route.ts
@@ -3,10 +3,29 @@ import { prisma } from '../../../../../lib/db';
 import { auth } from '../../../../../auth';
 import { enqueueFeedbackQC } from '../../../../../lib/queues';
 
-export async function GET(_req: NextRequest, { params }:{params:{bookingId:string}}){
-  const fb = await prisma.feedback.findUnique({ where: { bookingId: params.bookingId } });
-  if(!fb) return NextResponse.json({error:'not_found'}, {status:404});
-  return NextResponse.json(fb);
+export async function GET(_req: NextRequest, { params }: { params: { bookingId: string } }) {
+  const session = await auth();
+  if (!session?.user)
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const fb = await prisma.feedback.findUnique({
+    where: { bookingId: params.bookingId },
+    include: {
+      booking: { select: { candidateId: true, professionalId: true } },
+    },
+  });
+  if (!fb) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  if (
+    fb.booking.candidateId !== session.user.id &&
+    fb.booking.professionalId !== session.user.id &&
+    session.user.role !== 'ADMIN'
+  ) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+  }
+
+  const { booking, ...rest } = fb as any;
+  return NextResponse.json(rest);
 }
 
 export async function POST(req: NextRequest, { params }:{params:{bookingId:string}}){

--- a/src/app/candidate/history/page.tsx
+++ b/src/app/candidate/history/page.tsx
@@ -12,7 +12,7 @@ export default async function History() {
       ? `${c.professional.professionalProfile.title} at ${c.professional.professionalProfile.employer}`
       : c.professional.email,
     date: formatDateTime(c.startAt),
-    action: { label: "View Feedback", href: "#" },
+    action: { label: "View Feedback", href: `/candidate/history/${c.id}` },
   }));
 
   const columns = [


### PR DESCRIPTION
## Summary
- link call history rows to a feedback detail page
- add candidate feedback page that shows rating, actions, text, and QC info
- secure feedback API so only related users can fetch a booking's feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3dda20f988325b61fa5ea7762146a