### PR TITLE
Fix Next.js static chunk 404 by skipping auth middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,8 @@
+export { auth as middleware } from './auth';
+
+// Apply auth middleware to all routes except Next.js internals and static assets.
+// API routes are excluded here but must call `auth()` themselves for protection.
+export const config = {
+  matcher: ['/((?!_next|api|favicon.ico|.*\\..*).*)'],
+};
+


### PR DESCRIPTION
## Summary
- add middleware config so auth middleware skips `/_next`, `api`, `favicon.ico`, and static file paths
- document why API routes are excluded and note they must call `auth()` directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f334df5483259a1bfc3a26961f55