### PR TITLE
Filter candidate calls by owner and display professional names

### DIFF
--- a/src/app/candidate/calls/page.tsx
+++ b/src/app/candidate/calls/page.tsx
@@ -57,7 +57,6 @@ export default async function CallsPage({
       include: {
         professional: {
           select: {
-            email: true,
             firstName: true,
             lastName: true,
             professionalProfile: { select: { title: true, employer: true } },
@@ -69,6 +68,7 @@ export default async function CallsPage({
   ]);
 
   const filtered = bookings.filter((b) => {
+    if (b.candidateId !== session.user.id) return false;
     if (
       active.Title?.length &&
       !active.Title.includes(b.professional.professionalProfile?.title ?? "")
@@ -86,10 +86,9 @@ export default async function CallsPage({
   });
 
   const rows = filtered.map((b) => {
-    const name =
-      [b.professional.firstName, b.professional.lastName]
-        .filter(Boolean)
-        .join(" ") || b.professional.email;
+    const name = [b.professional.firstName, b.professional.lastName]
+      .filter(Boolean)
+      .join(" ");
     const daysSince = Math.floor(
       (Date.now() - new Date(b.createdAt).getTime()) / (1000 * 60 * 60 * 24)
     );


### PR DESCRIPTION
## Summary
- Restrict candidate calls list to bookings made by the logged-in candidate
- Display professional's full name rather than their email in the calls table

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5121c06188325b26dd9cab13e327c