### PR TITLE
Remove clickable status buttons and label call filters

### DIFF
--- a/src/app/candidate/calls/page.tsx
+++ b/src/app/candidate/calls/page.tsx
@@ -7,18 +7,19 @@ import {
 } from "../../../app/api/filterOptions";
 import { prisma } from "../../../../lib/db";
 import { BookingStatus } from "@prisma/client";
+import type { CSSProperties } from "react";
 
-function statusVariant(status: BookingStatus): "primary" | "danger" | "muted" {
+function statusStyle(status: BookingStatus): CSSProperties {
   switch (status) {
-    case "cancelled":
-    case "refunded":
-      return "danger";
-    case "accepted":
     case "completed":
     case "completed_pending_feedback":
-      return "primary";
+      return { backgroundColor: "var(--accent)", color: "white" };
+    case "accepted":
+      return { backgroundColor: "var(--success)", color: "white" };
+    case "requested":
+      return { backgroundColor: "var(--purple)", color: "white" };
     default:
-      return "muted";
+      return { backgroundColor: "var(--muted)", color: "var(--text-muted)" };
   }
 }
 
@@ -37,6 +38,7 @@ export default async function CallsPage({
   };
 
   const dateFilters = ["After", "Before"];
+  const dateFilterLabels = { After: "Start Date", Before: "End Date" };
   const active: ActiveFilters = {};
   [...Object.keys(filterConfig), ...dateFilters].forEach((key) => {
     const value = searchParams[key];
@@ -97,7 +99,11 @@ export default async function CallsPage({
       firm: b.professional.professionalProfile?.employer ?? "",
       title: b.professional.professionalProfile?.title ?? "",
       days: String(daysSince),
-      status: { label: b.status, variant: statusVariant(b.status) },
+      status: (
+        <span className="badge" style={statusStyle(b.status)}>
+          {b.status}
+        </span>
+      ),
     };
   });
 
@@ -117,8 +123,8 @@ export default async function CallsPage({
         columns={columns}
         filterOptions={filterOptions}
         initialActive={active}
-        buttonColumns={["status"]}
         dateFilters={dateFilters}
+        dateFilterLabels={dateFilterLabels}
       />
     </section>
   );

--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -13,7 +13,7 @@ interface LinkValue {
   variant?: 'primary' | 'danger' | 'muted';
 }
 
-type RowData = Record<string, string | string[] | LinkValue>;
+type RowData = Record<string, string | string[] | LinkValue | ReactNode>;
 
 interface Column {
   key: string;
@@ -28,6 +28,7 @@ interface Props {
   showFilters?: boolean;
   buttonColumns?: string[];
   dateFilters?: string[];
+  dateFilterLabels?: Record<string, string>;
 }
 
 export default function DashboardClient({
@@ -38,6 +39,7 @@ export default function DashboardClient({
   showFilters = true,
   buttonColumns = [],
   dateFilters = [],
+  dateFilterLabels = {},
 }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -119,10 +121,14 @@ export default function DashboardClient({
               dateFilters.includes(label) ? (
                 <Input
                   key={label}
-                  type="date"
+                  type={active[label]?.[0] ? 'date' : 'text'}
+                  placeholder={dateFilterLabels[label] || label}
                   value={active[label]?.[0] || ''}
+                  onFocus={(e) => (e.target.type = 'date')}
+                  onBlur={(e) => {
+                    if (!e.target.value) e.target.type = 'text';
+                  }}
                   onChange={(e) => handleDateChange(label, e.target.value)}
-                  placeholder={label}
                 />
               ) : (
                 <FilterDropdown

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -10,6 +10,7 @@
   --success: #16a34a;
   --danger: #dc2626;
   --warning: #f59e0b;
+  --purple: #9333ea;
   --radius: 16px;
   --shadow: 0 6px 24px rgba(0,0,0,0.08);
 }


### PR DESCRIPTION
## Summary
- show call statuses as colored badges without button interactions
- add purple theme color for requested calls
- show start/end date filter labels inside date fields as placeholders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52a00308483259185fb419973f43d