### PR TITLE
Store continuous availability ranges and expand on retrieval

### DIFF
--- a/lib/availability.ts
+++ b/lib/availability.ts
@@ -1,0 +1,35 @@
+export type Slot = { start: string; end: string };
+
+export function mergeSlots(slots: Slot[]): Slot[] {
+  if (!slots.length) return [];
+  const sorted = slots
+    .map((s) => ({ start: new Date(s.start), end: new Date(s.end) }))
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+  const merged: { start: Date; end: Date }[] = [];
+  let current = sorted[0];
+  for (let i = 1; i < sorted.length; i++) {
+    const slot = sorted[i];
+    if (slot.start.getTime() === current.end.getTime()) {
+      current.end = slot.end;
+    } else {
+      merged.push(current);
+      current = slot;
+    }
+  }
+  merged.push(current);
+  return merged.map((m) => ({ start: m.start.toISOString(), end: m.end.toISOString() }));
+}
+
+export function splitIntoSlots(ranges: Slot[], minutes = 30): Slot[] {
+  const result: Slot[] = [];
+  ranges.forEach((r) => {
+    const start = new Date(r.start);
+    const end = new Date(r.end);
+    for (let t = new Date(start); t < end; t.setMinutes(t.getMinutes() + minutes)) {
+      const slotStart = new Date(t);
+      const slotEnd = new Date(t.getTime() + minutes * 60 * 1000);
+      result.push({ start: slotStart.toISOString(), end: slotEnd.toISOString() });
+    }
+  });
+  return result;
+}

--- a/src/app/api/candidate/availability/route.ts
+++ b/src/app/api/candidate/availability/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { prisma } from '../../../../../lib/db';
+import { mergeSlots, splitIntoSlots } from '../../../../../lib/availability';
 
 export async function POST(req: Request){
   const session = await auth();
@@ -8,11 +9,30 @@ export async function POST(req: Request){
 
   const { events = [], busy = [] } = await req.json();
 
+  const mergedEvents = mergeSlots(events);
+  const mergedBusy = mergeSlots(busy);
+
   await prisma.availability.deleteMany({ where: { userId: session.user.id } });
   const data = [
-    ...events.map((e: any) => ({ userId: session.user.id, start: e.start, end: e.end, busy: false })),
-    ...busy.map((e: any) => ({ userId: session.user.id, start: e.start, end: e.end, busy: true })),
+    ...mergedEvents.map((e: any) => ({ userId: session.user.id, start: e.start, end: e.end, busy: false })),
+    ...mergedBusy.map((e: any) => ({ userId: session.user.id, start: e.start, end: e.end, busy: true })),
   ];
   if(data.length) await prisma.availability.createMany({ data });
   return NextResponse.json({ ok: true });
+}
+
+export async function GET(){
+  const session = await auth();
+  if(!session?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const rows = await prisma.availability.findMany({
+    where: { userId: session.user.id },
+    orderBy: { start: 'asc' },
+  });
+  const events = splitIntoSlots(
+    rows.filter(r => !r.busy).map(r => ({ start: r.start.toISOString(), end: r.end.toISOString() }))
+  );
+  const busy = splitIntoSlots(
+    rows.filter(r => r.busy).map(r => ({ start: r.start.toISOString(), end: r.end.toISOString() }))
+  );
+  return NextResponse.json({ events, busy });
 }

--- a/tests/availability.test.ts
+++ b/tests/availability.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { mergeSlots, splitIntoSlots, Slot } from '../lib/availability';
+
+describe('availability utilities', () => {
+  it('merges continuous slots into a single range', () => {
+    const slots: Slot[] = [
+      { start: '2024-01-01T09:00:00.000Z', end: '2024-01-01T09:30:00.000Z' },
+      { start: '2024-01-01T09:30:00.000Z', end: '2024-01-01T10:00:00.000Z' },
+      { start: '2024-01-01T11:00:00.000Z', end: '2024-01-01T11:30:00.000Z' },
+    ];
+    const merged = mergeSlots(slots);
+    expect(merged).toEqual([
+      { start: '2024-01-01T09:00:00.000Z', end: '2024-01-01T10:00:00.000Z' },
+      { start: '2024-01-01T11:00:00.000Z', end: '2024-01-01T11:30:00.000Z' },
+    ]);
+  });
+
+  it('splits ranges into 30-minute chunks', () => {
+    const ranges: Slot[] = [
+      { start: '2024-01-01T09:00:00.000Z', end: '2024-01-01T10:00:00.000Z' },
+    ];
+    const slots = splitIntoSlots(ranges);
+    expect(slots).toEqual([
+      { start: '2024-01-01T09:00:00.000Z', end: '2024-01-01T09:30:00.000Z' },
+      { start: '2024-01-01T09:30:00.000Z', end: '2024-01-01T10:00:00.000Z' },
+    ]);
+  });
+
+  it('round-trip merge and split', () => {
+    const slots: Slot[] = [
+      { start: '2024-01-01T09:00:00.000Z', end: '2024-01-01T09:30:00.000Z' },
+      { start: '2024-01-01T09:30:00.000Z', end: '2024-01-01T10:00:00.000Z' },
+    ];
+    const merged = mergeSlots(slots);
+    const expanded = splitIntoSlots(merged);
+    expect(expanded).toEqual(slots);
+  });
+});


### PR DESCRIPTION
## Summary
- compress contiguous availability slots into single ranges before persisting
- add utilities to merge and split availability slots
- return stored ranges expanded into 30‑minute chunks

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68b52cd8c79c8325a954133f8b393ce8