### PR TITLE
Add call date and feedback buttons to candidate calls page

### DIFF
--- a/src/app/candidate/calls/page.tsx
+++ b/src/app/candidate/calls/page.tsx
@@ -9,6 +9,7 @@ import {
 import { prisma } from "../../../../lib/db";
 import { BookingStatus } from "@prisma/client";
 import type { CSSProperties } from "react";
+import { formatDateTime } from "../../../../lib/date";
 
 function statusStyle(status: BookingStatus): CSSProperties {
   switch (status) {
@@ -103,16 +104,22 @@ export default async function CallsPage({
     const daysSince = Math.floor(
       (Date.now() - new Date(b.createdAt).getTime()) / (1000 * 60 * 60 * 24)
     );
+    const callDate = new Date(b.startAt);
+    const hasHappened = callDate.getTime() <= Date.now();
     return {
       name,
       firm: b.professional.professionalProfile?.employer ?? "",
       title: b.professional.professionalProfile?.title ?? "",
       days: String(daysSince),
+      date: { label: formatDateTime(callDate) },
       status: (
         <span className="badge" style={statusStyle(b.status)}>
           {b.status}
         </span>
       ),
+      feedback: hasHappened
+        ? { label: "View Feedback", href: `/candidate/history/${b.id}` }
+        : { label: "View Feedback", variant: "muted", disabled: true },
     };
   });
 
@@ -121,7 +128,9 @@ export default async function CallsPage({
     { key: "firm", label: "Firm" },
     { key: "title", label: "Title" },
     { key: "days", label: "Days Since Requested" },
+    { key: "date", label: "Date of Call" },
     { key: "status", label: "Status" },
+    { key: "feedback", label: "View Feedback" },
   ];
 
   return (
@@ -134,6 +143,7 @@ export default async function CallsPage({
         initialActive={active}
         dateFilters={dateFilters}
         dateFilterLabels={dateFilterLabels}
+        buttonColumns={["date", "feedback"]}
       />
       <Pagination page={page} totalPages={totalPages} />
     </section>

--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -11,6 +11,7 @@ interface LinkValue {
   label: string;
   href?: string;
   variant?: 'primary' | 'danger' | 'muted';
+  disabled?: boolean;
 }
 
 type RowData = Record<string, string | string[] | LinkValue | ReactNode>;
@@ -66,9 +67,13 @@ export default function DashboardClient({
           typeof val === 'object' &&
           'label' in val
         ) {
-          const { label, href, variant } = val as LinkValue;
-          const btn = <Button variant={variant}>{label}</Button>;
-          row[c.key] = href ? <Link href={href}>{btn}</Link> : btn;
+          const { label, href, variant, disabled } = val as LinkValue;
+          const btn = (
+            <Button variant={variant} disabled={disabled}>
+              {label}
+            </Button>
+          );
+          row[c.key] = href && !disabled ? <Link href={href}>{btn}</Link> : btn;
         } else if (val && typeof val === 'object' && 'label' in val) {
           row[c.key] = (val as LinkValue).label;
         } else if (Array.isArray(val)) {


### PR DESCRIPTION
## Summary
- show call date and feedback actions in candidate call dashboard
- disable feedback action for calls that haven't occurred
- allow DashboardClient buttons to be disabled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b53379860483258de943c8a168038e