### PR TITLE
Use booking request API and email professionals

### DIFF
--- a/src/app/candidate/detail/[id]/schedule/page.tsx
+++ b/src/app/candidate/detail/[id]/schedule/page.tsx
@@ -7,7 +7,7 @@ export default function Schedule({ params }: { params: { id: string } }) {
   const [weeks, setWeeks] = useState(2);
 
   const handleConfirm = async (slots: any[]) => {
-    await fetch('/api/candidate/availability/share', {
+    await fetch('/api/bookings/request', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ professionalId: params.id, slots, weeks }),


### PR DESCRIPTION
## Summary
- Use `/api/bookings/request` when candidates submit availability.
- Email the professional upon new booking requests.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b54eec547083259a5378a45fff4ef0