### PR TITLE
Use DashboardClient for professional requests

### DIFF
--- a/src/app/api/professional/requests.ts
+++ b/src/app/api/professional/requests.ts
@@ -3,7 +3,15 @@ import { prisma } from "../../../../lib/db";
 export async function getProfessionalRequests(userId: string) {
   return prisma.booking.findMany({
     where: { professionalId: userId, status: "requested" },
-    include: { candidate: true },
+    include: {
+      candidate: {
+        include: {
+          candidateProfile: {
+            include: { education: true },
+          },
+        },
+      },
+    },
     orderBy: { startAt: "asc" },
   });
 }


### PR DESCRIPTION
## Summary
- Present professional call requests via DashboardClient with candidate details and actions
- Fetch candidate profile and education to support interests and activities display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60acafc488325b8d59997597933f9