### PR TITLE
Embed pagination into DashboardClient

### DIFF
--- a/src/app/candidate/browse/page.tsx
+++ b/src/app/candidate/browse/page.tsx
@@ -6,7 +6,6 @@ import {
 } from "../../../app/api/filterOptions";
 import { listUsers } from "../../../app/api/users/list";
 import { Role } from "@prisma/client";
-import Pagination from "../../../components/Pagination";
 
 export default async function Browse({
   searchParams,
@@ -87,8 +86,9 @@ export default async function Browse({
         filterOptions={filterOptions}
         initialActive={active}
         buttonColumns={["action"]}
+        page={page}
+        totalPages={totalPages}
       />
-      <Pagination page={page} totalPages={totalPages} />
     </section>
   );
 }

--- a/src/app/candidate/calls/page.tsx
+++ b/src/app/candidate/calls/page.tsx
@@ -1,6 +1,5 @@
 import { auth } from "@/auth";
 import DashboardClient from "../../../components/DashboardClient";
-import Pagination from "../../../components/Pagination";
 import {
   getFilterOptions,
   FilterConfig,
@@ -144,8 +143,9 @@ export default async function CallsPage({
         dateFilters={dateFilters}
         dateFilterLabels={dateFilterLabels}
         buttonColumns={["feedback"]}
+        page={page}
+        totalPages={totalPages}
       />
-      <Pagination page={page} totalPages={totalPages} />
     </section>
   );
 }

--- a/src/app/candidate/dashboard/page.tsx
+++ b/src/app/candidate/dashboard/page.tsx
@@ -7,7 +7,6 @@ import {
 import { listUsers } from "../../../app/api/users/list";
 import { Role } from "@prisma/client";
 import DashboardClient from "../../../components/DashboardClient";
-import Pagination from "../../../components/Pagination";
 
 export default async function CandidateDashboard({
   searchParams,
@@ -91,8 +90,9 @@ export default async function CandidateDashboard({
         filterOptions={filterOptions}
         initialActive={active}
         buttonColumns={["action"]}
+        page={page}
+        totalPages={totalPages}
       />
-      <Pagination page={page} totalPages={totalPages} />
     </section>
   );
 }

--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState, ReactNode } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import FilterDropdown from './FilterDropdown';
 import { Card, Button, DataTable, Input } from './ui';
+import Pagination from './Pagination';
 import { ActiveFilters } from '../app/api/filterOptions';
 
 interface LinkValue {
@@ -30,6 +31,8 @@ interface Props {
   buttonColumns?: string[];
   dateFilters?: string[];
   dateFilterLabels?: Record<string, string>;
+  page?: number;
+  totalPages?: number;
 }
 
 export default function DashboardClient({
@@ -41,6 +44,8 @@ export default function DashboardClient({
   buttonColumns = [],
   dateFilters = [],
   dateFilterLabels = {},
+  page,
+  totalPages,
 }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -152,6 +157,9 @@ export default function DashboardClient({
       <Card style={{ padding: 0 }}>
         <DataTable columns={columns as any} rows={tableRows as any} />
       </Card>
+      {typeof page === 'number' && typeof totalPages === 'number' && (
+        <Pagination page={page} totalPages={totalPages} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Embed Pagination component inside DashboardClient with optional page and totalPages props
- Update candidate Calls, Dashboard, and Browse pages to rely on DashboardClient's built-in pagination

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b60df5556483259718a39128b5f4ea