### PR TITLE
Align feedback date to the right

### DIFF
--- a/src/app/professional/feedback/page.tsx
+++ b/src/app/professional/feedback/page.tsx
@@ -15,11 +15,15 @@ export default async function FeedbackPage() {
       <div className="col" style={{ gap: 12 }}>
         {feedback.map((f) => (
           <div key={f.bookingId} className="card" style={{ padding: 16 }}>
-            <strong>{`${f.booking.candidate.firstName} ${f.booking.candidate.lastName}`}</strong>
-            <span style={{ color: 'var(--text-muted)' }}>
-              {format(f.submittedAt, 'MMMM d, yyyy')}
-            </span>
-            <div>{'★'.repeat(f.rating)}{'☆'.repeat(5 - f.rating)}</div>
+            <div className="row" style={{ justifyContent: 'space-between' }}>
+              <strong>{`${f.booking.candidate.firstName} ${f.booking.candidate.lastName}`}</strong>
+              <span style={{ color: 'var(--text-muted)' }}>
+                {format(f.submittedAt, 'MMMM d, yyyy')}
+              </span>
+            </div>
+            <div>
+              {'★'.repeat(f.rating)}{'☆'.repeat(5 - f.rating)}
+            </div>
             <p>{f.text}</p>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- Align feedback card headers with name and submission date in a row, pushing the date to the far right.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6118640508325a2d1a5ec91eeab5d