### PR TITLE
Add pagination to remaining DashboardClient pages

### DIFF
--- a/src/app/api/bookings/history.ts
+++ b/src/app/api/bookings/history.ts
@@ -1,22 +1,31 @@
 import { prisma } from "../../../../lib/db";
 
-export async function getPastCalls(candidateId: string) {
-  return prisma.booking.findMany({
-    where: {
-      candidateId,
-      startAt: { lt: new Date() },
-    },
-    include: {
-      professional: {
-        select: {
-          email: true,
-          professionalProfile: {
-            select: { title: true, employer: true },
+export async function getPastCalls(
+  candidateId: string,
+  page: number,
+  perPage: number
+) {
+  const where = { candidateId, startAt: { lt: new Date() } } as const;
+  const [calls, total] = await Promise.all([
+    prisma.booking.findMany({
+      where,
+      include: {
+        professional: {
+          select: {
+            email: true,
+            professionalProfile: {
+              select: { title: true, employer: true },
+            },
           },
         },
       },
-    },
-    orderBy: { startAt: 'desc' },
-  });
+      orderBy: { startAt: 'desc' },
+      skip: (page - 1) * perPage,
+      take: perPage,
+    }),
+    prisma.booking.count({ where }),
+  ]);
+
+  return { calls, totalPages: Math.ceil(total / perPage) };
 }
 

--- a/src/app/api/professional/earnings.ts
+++ b/src/app/api/professional/earnings.ts
@@ -1,30 +1,56 @@
 import { prisma } from "../../../../lib/db";
 import { PaymentStatus } from "@prisma/client";
 
-export async function getProfessionalEarnings(userId: string) {
-  const payments = await prisma.payment.findMany({
-    where: { booking: { professionalId: userId } },
-    include: { booking: { include: { candidate: true } } },
-    orderBy: { createdAt: "desc" },
-  });
-
-  const total = payments
-    .filter((p) => p.status === PaymentStatus.released)
-    .reduce((sum, p) => sum + (p.amountGross - p.platformFee), 0);
-
+export async function getProfessionalEarnings(
+  userId: string,
+  page: number,
+  perPage: number
+) {
   const monthStart = new Date();
   monthStart.setDate(1);
   monthStart.setHours(0, 0, 0, 0);
-  const currentMonth = payments
-    .filter(
-      (p) => p.status === PaymentStatus.released && p.createdAt >= monthStart
-    )
-    .reduce((sum, p) => sum + (p.amountGross - p.platformFee), 0);
 
-  const pending = payments
-    .filter((p) => p.status === PaymentStatus.held)
-    .reduce((sum, p) => sum + (p.amountGross - p.platformFee), 0);
+  const where = { booking: { professionalId: userId } } as const;
 
-  return { stats: { total, currentMonth, pending }, payments };
+  const [payments, totalCount, totalAgg, currentMonthAgg, pendingAgg] =
+    await Promise.all([
+      prisma.payment.findMany({
+        where,
+        include: { booking: { include: { candidate: true } } },
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * perPage,
+        take: perPage,
+      }),
+      prisma.payment.count({ where }),
+      prisma.payment.aggregate({
+        where: { ...where, status: PaymentStatus.released },
+        _sum: { amountGross: true, platformFee: true },
+      }),
+      prisma.payment.aggregate({
+        where: {
+          ...where,
+          status: PaymentStatus.released,
+          createdAt: { gte: monthStart },
+        },
+        _sum: { amountGross: true, platformFee: true },
+      }),
+      prisma.payment.aggregate({
+        where: { ...where, status: PaymentStatus.held },
+        _sum: { amountGross: true, platformFee: true },
+      }),
+    ]);
+
+  const stats = {
+    total:
+      (totalAgg._sum.amountGross ?? 0) - (totalAgg._sum.platformFee ?? 0),
+    currentMonth:
+      (currentMonthAgg._sum.amountGross ?? 0) -
+      (currentMonthAgg._sum.platformFee ?? 0),
+    pending:
+      (pendingAgg._sum.amountGross ?? 0) -
+      (pendingAgg._sum.platformFee ?? 0),
+  };
+
+  return { stats, payments, totalPages: Math.ceil(totalCount / perPage) };
 }
 

--- a/src/app/api/professional/requests.ts
+++ b/src/app/api/professional/requests.ts
@@ -1,18 +1,31 @@
 import { prisma } from "../../../../lib/db";
 
-export async function getProfessionalRequests(userId: string) {
-  return prisma.booking.findMany({
-    where: { professionalId: userId, status: "requested" },
-    include: {
-      candidate: {
-        include: {
-          candidateProfile: {
-            include: { education: true },
+export async function getProfessionalRequests(
+  userId: string,
+  page: number,
+  perPage: number
+) {
+  const where = { professionalId: userId, status: "requested" } as const;
+
+  const [requests, total] = await Promise.all([
+    prisma.booking.findMany({
+      where,
+      include: {
+        candidate: {
+          include: {
+            candidateProfile: {
+              include: { education: true },
+            },
           },
         },
       },
-    },
-    orderBy: { startAt: "asc" },
-  });
+      orderBy: { startAt: "asc" },
+      skip: (page - 1) * perPage,
+      take: perPage,
+    }),
+    prisma.booking.count({ where }),
+  ]);
+
+  return { requests, totalPages: Math.ceil(total / perPage) };
 }
 

--- a/src/app/candidate/browse/page.tsx
+++ b/src/app/candidate/browse/page.tsx
@@ -6,7 +6,6 @@ import {
 } from "../../../app/api/filterOptions";
 import { listUsers } from "../../../app/api/users/list";
 import { Role } from "@prisma/client";
-import Pagination from "../../../components/Pagination";
 
 export default async function Browse({
   searchParams,
@@ -87,8 +86,9 @@ export default async function Browse({
         filterOptions={filterOptions}
         initialActive={active}
         buttonColumns={["action"]}
+        page={page}
+        totalPages={totalPages}
       />
-      <Pagination page={page} totalPages={totalPages} />
     </section>
   );
 }

--- a/src/app/candidate/calls/page.tsx
+++ b/src/app/candidate/calls/page.tsx
@@ -1,6 +1,5 @@
 import { auth } from "@/auth";
 import DashboardClient from "../../../components/DashboardClient";
-import Pagination from "../../../components/Pagination";
 import {
   getFilterOptions,
   FilterConfig,
@@ -144,8 +143,9 @@ export default async function CallsPage({
         dateFilters={dateFilters}
         dateFilterLabels={dateFilterLabels}
         buttonColumns={["feedback"]}
+        page={page}
+        totalPages={totalPages}
       />
-      <Pagination page={page} totalPages={totalPages} />
     </section>
   );
 }

--- a/src/app/candidate/dashboard/page.tsx
+++ b/src/app/candidate/dashboard/page.tsx
@@ -7,7 +7,6 @@ import {
 import { listUsers } from "../../../app/api/users/list";
 import { Role } from "@prisma/client";
 import DashboardClient from "../../../components/DashboardClient";
-import Pagination from "../../../components/Pagination";
 
 export default async function CandidateDashboard({
   searchParams,
@@ -91,8 +90,9 @@ export default async function CandidateDashboard({
         filterOptions={filterOptions}
         initialActive={active}
         buttonColumns={["action"]}
+        page={page}
+        totalPages={totalPages}
       />
-      <Pagination page={page} totalPages={totalPages} />
     </section>
   );
 }

--- a/src/app/candidate/history/page.tsx
+++ b/src/app/candidate/history/page.tsx
@@ -3,9 +3,17 @@ import DashboardClient from "../../../components/DashboardClient";
 import { getPastCalls } from "../../../app/api/bookings/history";
 import { formatDateTime } from "../../../../lib/date";
 
-export default async function History() {
+export default async function History({
+  searchParams,
+}: {
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
   const session = await auth();
-  const calls = session?.user.id ? await getPastCalls(session.user.id) : [];
+  const page = Number(searchParams.page) || 1;
+  const perPage = 10;
+  const { calls, totalPages } = session?.user.id
+    ? await getPastCalls(session.user.id, page, perPage)
+    : { calls: [], totalPages: 1 };
 
   const rows = calls.map((c) => ({
     title: c.professional.professionalProfile
@@ -27,6 +35,8 @@ export default async function History() {
       columns={columns}
       showFilters={false}
       buttonColumns={["action"]}
+      page={page}
+      totalPages={totalPages}
     />
   );
 }

--- a/src/app/professional/dashboard/page.tsx
+++ b/src/app/professional/dashboard/page.tsx
@@ -4,12 +4,21 @@ import { auth } from "@/auth";
 import { getProfessionalDashboardData } from "../../api/professional/dashboard";
 import { format } from "date-fns";
 
-export default async function ProDashboard() {
+export default async function ProDashboard({
+  searchParams,
+}: {
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
   const session = await auth();
   if (!session?.user) return null;
 
-  const { upcoming, stats } = await getProfessionalDashboardData(
-    session.user.id
+  const page = Number(searchParams.page) || 1;
+  const perPage = 10;
+
+  const { upcoming, stats, totalPages } = await getProfessionalDashboardData(
+    session.user.id,
+    page,
+    perPage
   );
 
   const rows = upcoming.map((b) => ({
@@ -34,6 +43,8 @@ export default async function ProDashboard() {
         columns={columns}
         showFilters={false}
         buttonColumns={["action"]}
+        page={page}
+        totalPages={totalPages}
       />
       <div className="grid grid-2">
         <Card style={{ padding: 16 }}>

--- a/src/app/professional/earnings/page.tsx
+++ b/src/app/professional/earnings/page.tsx
@@ -4,11 +4,22 @@ import { auth } from "@/auth";
 import { getProfessionalEarnings } from "../../api/professional/earnings";
 import { format } from "date-fns";
 
-export default async function Earnings() {
+export default async function Earnings({
+  searchParams,
+}: {
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
   const session = await auth();
   if (!session?.user) return null;
 
-  const { stats, payments } = await getProfessionalEarnings(session.user.id);
+  const page = Number(searchParams.page) || 1;
+  const perPage = 10;
+
+  const { stats, payments, totalPages } = await getProfessionalEarnings(
+    session.user.id,
+    page,
+    perPage
+  );
 
   const rows = payments.map((p) => ({
     date: format(p.createdAt, "MMMM d, yyyy"),
@@ -48,7 +59,13 @@ export default async function Earnings() {
           </div>
         </div>
       </Card>
-      <DashboardClient data={rows} columns={columns} showFilters={false} />
+      <DashboardClient
+        data={rows}
+        columns={columns}
+        showFilters={false}
+        page={page}
+        totalPages={totalPages}
+      />
     </section>
   );
 }

--- a/src/app/professional/requests/page.tsx
+++ b/src/app/professional/requests/page.tsx
@@ -4,11 +4,22 @@ import { Button, Badge } from "../../../components/ui";
 import { auth } from "@/auth";
 import { getProfessionalRequests } from "../../api/professional/requests";
 
-export default async function Requests() {
+export default async function Requests({
+  searchParams,
+}: {
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
   const session = await auth();
   if (!session?.user) return null;
 
-  const requests = await getProfessionalRequests(session.user.id);
+  const page = Number(searchParams.page) || 1;
+  const perPage = 10;
+
+  const { requests, totalPages } = await getProfessionalRequests(
+    session.user.id,
+    page,
+    perPage
+  );
 
   const rows = requests.map((r) => {
     const candidate = r.candidate;
@@ -53,7 +64,13 @@ export default async function Requests() {
   return (
     <section className="col" style={{ gap: 16 }}>
       <h2>Requests</h2>
-      <DashboardClient data={rows} columns={columns} showFilters={false} />
+      <DashboardClient
+        data={rows}
+        columns={columns}
+        showFilters={false}
+        page={page}
+        totalPages={totalPages}
+      />
     </section>
   );
 }

--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -5,6 +5,7 @@ import { useMemo, useState, ReactNode } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import FilterDropdown from './FilterDropdown';
 import { Card, Button, DataTable, Input } from './ui';
+import Pagination from './Pagination';
 import { ActiveFilters } from '../app/api/filterOptions';
 
 interface LinkValue {
@@ -30,6 +31,8 @@ interface Props {
   buttonColumns?: string[];
   dateFilters?: string[];
   dateFilterLabels?: Record<string, string>;
+  page?: number;
+  totalPages?: number;
 }
 
 export default function DashboardClient({
@@ -41,6 +44,8 @@ export default function DashboardClient({
   buttonColumns = [],
   dateFilters = [],
   dateFilterLabels = {},
+  page,
+  totalPages,
 }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -152,6 +157,9 @@ export default function DashboardClient({
       <Card style={{ padding: 0 }}>
         <DataTable columns={columns as any} rows={tableRows as any} />
       </Card>
+      {typeof page === 'number' && typeof totalPages === 'number' && (
+        <Pagination page={page} totalPages={totalPages} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- paginate professional requests, earnings, and dashboard pages
- paginate candidate call history
- update data providers to return total pages for DashboardClient

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: Cannot find module '../../../../lib/db' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b60df5556483259718a39128b5f4ea