### PR TITLE
Add professional feedback dashboards

### DIFF
--- a/src/app/api/professional/feedback.ts
+++ b/src/app/api/professional/feedback.ts
@@ -1,10 +1,35 @@
 import { prisma } from "../../../../lib/db";
 
-export async function getProfessionalFeedback(userId: string) {
-  return prisma.professionalReview.findMany({
-    where: { booking: { professionalId: userId } },
-    include: { booking: { include: { candidate: true } } },
-    orderBy: { submittedAt: "desc" },
+export async function getProvidedFeedback(userId: string) {
+  return prisma.booking.findMany({
+    where: { professionalId: userId, feedback: { not: null } },
+    include: {
+      candidate: {
+        include: {
+          candidateProfile: { include: { education: true } },
+        },
+      },
+      feedback: true,
+    },
+    orderBy: { startAt: "desc" },
+  });
+}
+
+export async function getPendingFeedback(userId: string) {
+  return prisma.booking.findMany({
+    where: {
+      professionalId: userId,
+      feedback: null,
+      status: "completed_pending_feedback",
+    },
+    include: {
+      candidate: {
+        include: {
+          candidateProfile: { include: { education: true } },
+        },
+      },
+    },
+    orderBy: { startAt: "desc" },
   });
 }
 

--- a/src/app/professional/feedback/page.tsx
+++ b/src/app/professional/feedback/page.tsx
@@ -1,35 +1,76 @@
-import { Card } from "../../../components/ui";
+import DashboardClient from "../../../components/DashboardClient";
 import { auth } from "@/auth";
-import { getProfessionalFeedback } from "../../api/professional/feedback";
+import { getProvidedFeedback, getPendingFeedback } from "../../api/professional/feedback";
 import { format } from "date-fns";
 
 export default async function FeedbackPage() {
   const session = await auth();
   if (!session?.user) return null;
 
-  const feedback = await getProfessionalFeedback(session.user.id);
+  const [provided, pending] = await Promise.all([
+    getProvidedFeedback(session.user.id),
+    getPendingFeedback(session.user.id),
+  ]);
+
+  const providedRows = provided.map((b) => {
+    const candidate = b.candidate;
+    const name = `${candidate.firstName ?? ""} ${candidate.lastName ?? ""}`.trim() ||
+      candidate.email;
+    const edu = candidate.candidateProfile?.education?.[0];
+    const education = edu ? `${edu.title} @ ${edu.school}` : "";
+    return {
+      name,
+      education,
+      date: format(b.startAt, "MMMM d, yyyy"),
+      feedback: { label: "View Feedback", href: `/candidate/history/${b.id}` },
+    };
+  });
+
+  const pendingRows = pending.map((b) => {
+    const candidate = b.candidate;
+    const name = `${candidate.firstName ?? ""} ${candidate.lastName ?? ""}`.trim() ||
+      candidate.email;
+    const edu = candidate.candidateProfile?.education?.[0];
+    const education = edu ? `${edu.title} @ ${edu.school}` : "";
+    return {
+      name,
+      education,
+      date: format(b.startAt, "MMMM d, yyyy"),
+      feedback: { label: "Provide Feedback", href: `/candidate/history/${b.id}` },
+    };
+  });
+
+  const providedColumns = [
+    { key: "name", label: "Name" },
+    { key: "education", label: "Education" },
+    { key: "date", label: "Date of Meeting" },
+    { key: "feedback", label: "View Feedback" },
+  ];
+
+  const pendingColumns = [
+    { key: "name", label: "Name" },
+    { key: "education", label: "Education" },
+    { key: "date", label: "Date of Meeting" },
+    { key: "feedback", label: "Provide Feedback" },
+  ];
 
   return (
-    <Card style={{ padding: 16 }}>
-      <h2>Feedback</h2>
-      <div className="col" style={{ gap: 12 }}>
-        {feedback.map((f) => (
-          <div key={f.bookingId} className="card" style={{ padding: 16 }}>
-            <div className="row" style={{ justifyContent: 'space-between' }}>
-              <strong>{`${f.booking.candidate.firstName} ${f.booking.candidate.lastName}`}</strong>
-              <span style={{ color: 'var(--text-muted)' }}>
-                {format(f.submittedAt, 'MMMM d, yyyy')}
-              </span>
-            </div>
-            <div>
-              {'★'.repeat(f.rating)}{'☆'.repeat(5 - f.rating)}
-            </div>
-            <p>{f.text}</p>
-          </div>
-        ))}
-        {feedback.length === 0 && <p>No feedback yet.</p>}
-      </div>
-    </Card>
+    <section className="col" style={{ gap: 16 }}>
+      <h2>Provided Feedback</h2>
+      <DashboardClient
+        data={providedRows}
+        columns={providedColumns}
+        showFilters={false}
+        buttonColumns={["feedback"]}
+      />
+      <h2>Pending Feedback</h2>
+      <DashboardClient
+        data={pendingRows}
+        columns={pendingColumns}
+        showFilters={false}
+        buttonColumns={["feedback"]}
+      />
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary
- show provided and pending feedback via DashboardClient tables
- expose helper methods to fetch provided and pending feedback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b61862df4c832590df82938411c8ac