### PR TITLE
feat: add pagination to feedback tables

### DIFF
--- a/src/app/api/professional/feedback.ts
+++ b/src/app/api/professional/feedback.ts
@@ -1,35 +1,61 @@
 import { prisma } from "../../../../lib/db";
 
-export async function getProvidedFeedback(userId: string) {
-  return prisma.booking.findMany({
-    where: { professionalId: userId, feedback: { isNot: null } },
-    include: {
-      candidate: {
-        include: {
-          candidateProfile: { include: { education: true } },
+export async function getProvidedFeedback(
+  userId: string,
+  page: number,
+  perPage: number
+) {
+  const where = { professionalId: userId, feedback: { isNot: null } } as const;
+
+  const [feedback, total] = await Promise.all([
+    prisma.booking.findMany({
+      where,
+      include: {
+        candidate: {
+          include: {
+            candidateProfile: { include: { education: true } },
+          },
         },
+        feedback: true,
       },
-      feedback: true,
-    },
-    orderBy: { startAt: "desc" },
-  });
+      orderBy: { startAt: "desc" },
+      skip: (page - 1) * perPage,
+      take: perPage,
+    }),
+    prisma.booking.count({ where }),
+  ]);
+
+  return { feedback, totalPages: Math.ceil(total / perPage) };
 }
 
-export async function getPendingFeedback(userId: string) {
-  return prisma.booking.findMany({
-    where: {
-      professionalId: userId,
-      feedback: { is: null },
-      status: "completed_pending_feedback",
-    },
-    include: {
-      candidate: {
-        include: {
-          candidateProfile: { include: { education: true } },
+export async function getPendingFeedback(
+  userId: string,
+  page: number,
+  perPage: number
+) {
+  const where = {
+    professionalId: userId,
+    feedback: { is: null },
+    status: "completed_pending_feedback",
+  } as const;
+
+  const [feedback, total] = await Promise.all([
+    prisma.booking.findMany({
+      where,
+      include: {
+        candidate: {
+          include: {
+            candidateProfile: { include: { education: true } },
+          },
         },
       },
-    },
-    orderBy: { startAt: "desc" },
-  });
+      orderBy: { startAt: "desc" },
+      skip: (page - 1) * perPage,
+      take: perPage,
+    }),
+    prisma.booking.count({ where }),
+  ]);
+
+  return { feedback, totalPages: Math.ceil(total / perPage) };
 }
 

--- a/src/app/professional/feedback/page.tsx
+++ b/src/app/professional/feedback/page.tsx
@@ -3,13 +3,24 @@ import { auth } from "@/auth";
 import { getProvidedFeedback, getPendingFeedback } from "../../api/professional/feedback";
 import { format } from "date-fns";
 
-export default async function FeedbackPage() {
+export default async function FeedbackPage({
+  searchParams,
+}: {
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
   const session = await auth();
   if (!session?.user) return null;
 
-  const [provided, pending] = await Promise.all([
-    getProvidedFeedback(session.user.id),
-    getPendingFeedback(session.user.id),
+  const providedPage = Number(searchParams.providedPage) || 1;
+  const pendingPage = Number(searchParams.pendingPage) || 1;
+  const perPage = 10;
+
+  const [
+    { feedback: provided, totalPages: providedTotalPages },
+    { feedback: pending, totalPages: pendingTotalPages },
+  ] = await Promise.all([
+    getProvidedFeedback(session.user.id, providedPage, perPage),
+    getPendingFeedback(session.user.id, pendingPage, perPage),
   ]);
 
   const providedRows = provided.map((b) => {
@@ -62,6 +73,9 @@ export default async function FeedbackPage() {
         columns={providedColumns}
         showFilters={false}
         buttonColumns={["feedback"]}
+        page={providedPage}
+        totalPages={providedTotalPages}
+        pageParam="providedPage"
       />
       <h2>Pending Feedback</h2>
       <DashboardClient
@@ -69,6 +83,9 @@ export default async function FeedbackPage() {
         columns={pendingColumns}
         showFilters={false}
         buttonColumns={["feedback"]}
+        page={pendingPage}
+        totalPages={pendingTotalPages}
+        pageParam="pendingPage"
       />
     </section>
   );

--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -33,6 +33,7 @@ interface Props {
   dateFilterLabels?: Record<string, string>;
   page?: number;
   totalPages?: number;
+  pageParam?: string;
 }
 
 export default function DashboardClient({
@@ -46,6 +47,7 @@ export default function DashboardClient({
   dateFilterLabels = {},
   page,
   totalPages,
+  pageParam = 'page',
 }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -115,7 +117,7 @@ export default function DashboardClient({
         params.delete(label);
       }
     });
-    params.delete('page');
+    params.delete(pageParam);
     router.push(`?${params.toString()}`);
   };
 
@@ -158,7 +160,7 @@ export default function DashboardClient({
         <DataTable columns={columns as any} rows={tableRows as any} />
       </Card>
       {typeof page === 'number' && typeof totalPages === 'number' && (
-        <Pagination page={page} totalPages={totalPages} />
+        <Pagination page={page} totalPages={totalPages} param={pageParam} />
       )}
     </div>
   );

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -7,14 +7,15 @@ import { useSearchParams } from 'next/navigation';
 interface Props {
   page: number;
   totalPages: number;
+  param?: string;
 }
 
-export default function Pagination({ page, totalPages }: Props) {
+export default function Pagination({ page, totalPages, param = 'page' }: Props) {
   const searchParams = useSearchParams();
 
   const createHref = (p: number) => {
     const params = new URLSearchParams(searchParams.toString());
-    params.set('page', p.toString());
+    params.set(param, p.toString());
     return `?${params.toString()}`;
   };
 


### PR DESCRIPTION
## Summary
- add paginated queries for provided and pending feedback
- support custom pagination params in shared components
- paginate professional feedback tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b61e35de888325a733126e16d7011e