### PR TITLE
Add professional feedback history and submission form

### DIFF
--- a/src/app/api/feedback/[bookingId]/route.ts
+++ b/src/app/api/feedback/[bookingId]/route.ts
@@ -11,7 +11,20 @@ export async function GET(_req: NextRequest, { params }: { params: { bookingId: 
   const fb = await prisma.feedback.findUnique({
     where: { bookingId: params.bookingId },
     include: {
-      booking: { select: { candidateId: true, professionalId: true } },
+      booking: {
+        select: {
+          candidateId: true,
+          professionalId: true,
+          candidate: { select: { firstName: true, lastName: true, email: true } },
+          professional: {
+            select: {
+              firstName: true,
+              lastName: true,
+              professionalProfile: { select: { title: true, employer: true } },
+            },
+          },
+        },
+      },
     },
   });
   if (!fb) return NextResponse.json({ error: 'not_found' }, { status: 404 });
@@ -23,8 +36,7 @@ export async function GET(_req: NextRequest, { params }: { params: { bookingId: 
     return NextResponse.json({ error: 'forbidden' }, { status: 403 });
   }
 
-  const { booking, ...rest } = fb as any;
-  return NextResponse.json(rest);
+  return NextResponse.json(fb);
 }
 
 export async function POST(req: NextRequest, { params }:{params:{bookingId:string}}){

--- a/src/app/professional/feedback/[bookingId]/page.tsx
+++ b/src/app/professional/feedback/[bookingId]/page.tsx
@@ -1,0 +1,55 @@
+import { auth } from "@/auth";
+import { redirect } from "next/navigation";
+import { Card, Input, Button } from "../../../../components/ui";
+
+export default async function ProvideFeedbackPage({
+  params,
+}: {
+  params: { bookingId: string };
+}) {
+  const session = await auth();
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  return (
+    <section className="col" style={{ gap: 16 }}>
+      <h2>Provide Feedback</h2>
+      <Card className="col" style={{ padding: 16, gap: 16 }}>
+        <form className="col" style={{ gap: 16 }}>
+          <div className="col" style={{ gap: 4 }}>
+            <h3>Category 1 Rating</h3>
+            <p className="text-sm">Evaluate core technical skills.</p>
+            <Input type="number" name="starsCategory1" min={1} max={5} />
+          </div>
+          <div className="col" style={{ gap: 4 }}>
+            <h3>Category 2 Rating</h3>
+            <p className="text-sm">Assess communication and collaboration.</p>
+            <Input type="number" name="starsCategory2" min={1} max={5} />
+          </div>
+          <div className="col" style={{ gap: 4 }}>
+            <h3>Category 3 Rating</h3>
+            <p className="text-sm">Judge problem-solving approach.</p>
+            <Input type="number" name="starsCategory3" min={1} max={5} />
+          </div>
+          <div className="col" style={{ gap: 4 }}>
+            <h3>Extra Category Ratings</h3>
+            <p className="text-sm">Optional JSON of additional categories and scores.</p>
+            <textarea name="extraCategoryRatings" className="input" rows={2} />
+          </div>
+          <div className="col" style={{ gap: 4 }}>
+            <h3>Action Items</h3>
+            <p className="text-sm">List concrete next steps, one per line.</p>
+            <textarea name="actions" className="input" rows={3} />
+          </div>
+          <div className="col" style={{ gap: 4 }}>
+            <h3>Written Feedback</h3>
+            <p className="text-sm">Provide a narrative summary of the session.</p>
+            <textarea name="text" className="input" rows={5} />
+          </div>
+          <Button type="submit">Submit</Button>
+        </form>
+      </Card>
+    </section>
+  );
+}

--- a/src/app/professional/feedback/page.tsx
+++ b/src/app/professional/feedback/page.tsx
@@ -33,7 +33,7 @@ export default async function FeedbackPage({
       name,
       education,
       date: format(b.startAt, "MMMM d, yyyy"),
-      feedback: { label: "View Feedback", href: `/candidate/history/${b.id}` },
+      feedback: { label: "View Feedback", href: `/professional/history/${b.id}` },
     };
   });
 
@@ -47,7 +47,7 @@ export default async function FeedbackPage({
       name,
       education,
       date: format(b.startAt, "MMMM d, yyyy"),
-      feedback: { label: "Provide Feedback", href: `/candidate/history/${b.id}` },
+      feedback: { label: "Provide Feedback", href: `/professional/feedback/${b.id}` },
     };
   });
 

--- a/src/app/professional/history/[bookingId]/page.tsx
+++ b/src/app/professional/history/[bookingId]/page.tsx
@@ -3,7 +3,11 @@ import HistoricalFeedback from "../../../../components/HistoricalFeedback";
 import { notFound, redirect } from "next/navigation";
 import { Feedback } from "@prisma/client";
 
-export default async function FeedbackPage({ params }: { params: { bookingId: string } }) {
+export default async function ProfessionalHistoryPage({
+  params,
+}: {
+  params: { bookingId: string };
+}) {
   const session = await auth();
   if (!session?.user) {
     redirect("/login");
@@ -18,25 +22,19 @@ export default async function FeedbackPage({ params }: { params: { bookingId: st
   if (!res.ok) throw new Error("Failed to load feedback");
   type FeedbackResponse = Feedback & {
     booking: {
-      professional: {
+      candidate: {
         firstName: string | null;
         lastName: string | null;
-        professionalProfile: {
-          title: string | null;
-          employer: string | null;
-        } | null;
+        email: string;
       } | null;
     };
   };
   const feedback: FeedbackResponse = await res.json();
 
-  const pro = feedback.booking.professional;
-  const name = `${pro.firstName ?? ""} ${pro.lastName ?? ""}`.trim();
-  const profile = pro.professionalProfile;
-  const titleEmployer = profile
-    ? `${profile.title} @ ${profile.employer}`
-    : undefined;
-  const heading = [name, titleEmployer].filter(Boolean).join(", ");
+  const candidate = feedback.booking.candidate;
+  const heading =
+    `${candidate.firstName ?? ""} ${candidate.lastName ?? ""}`.trim() ||
+    candidate.email;
 
   return (
     <section className="col" style={{ gap: 16 }}>

--- a/src/components/HistoricalFeedback.tsx
+++ b/src/components/HistoricalFeedback.tsx
@@ -1,0 +1,39 @@
+import { Feedback } from "@prisma/client";
+import { Card } from "./ui";
+import { formatDateTime } from "../../lib/date";
+
+export default function HistoricalFeedback({ feedback }: { feedback: Feedback }) {
+  const extraRatings = feedback.extraCategoryRatings as Record<string, number>;
+  return (
+    <Card className="col" style={{ padding: 16, gap: 8 }}>
+      <p>
+        <strong>Submitted:</strong> {formatDateTime(feedback.submittedAt)}
+      </p>
+      <div>
+        <strong>Ratings</strong>
+        <ul>
+          <li>Category 1: {feedback.starsCategory1}</li>
+          <li>Category 2: {feedback.starsCategory2}</li>
+          <li>Category 3: {feedback.starsCategory3}</li>
+          {Object.entries(extraRatings).map(([k, v]) => (
+            <li key={k}>
+              {k}: {v as number}
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <strong>Summary</strong>
+        <ul>
+          {feedback.actions.map((a, i) => (
+            <li key={i}>{a}</li>
+          ))}
+        </ul>
+      </div>
+      <p>
+        <strong>Written Feedback:</strong>
+      </p>
+      <p>{feedback.text}</p>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- create reusable historical feedback component used by candidate and professional history pages
- add professional history view and feedback submission form
- route feedback data through API to avoid Prisma calls in pages

## Testing
- `npm test`
- `npm run test:e2e`
- `npm run lint` (fails: Missing script "lint")


------
https://chatgpt.com/codex/tasks/task_e_68b629eef78083258acbee24d1a8ae7e