### PR TITLE
Avoid unnecessary Redis connection in feedback routes

### DIFF
--- a/src/app/api/feedback/[bookingId]/route.ts
+++ b/src/app/api/feedback/[bookingId]/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '../../../../../lib/db';
 import { auth } from '@/auth';
-import { enqueueFeedbackQC } from '../../../../../lib/queues';
 
 export async function GET(_req: NextRequest, { params }: { params: { bookingId: string } }) {
   const session = await auth();
@@ -53,6 +52,7 @@ export async function POST(req: NextRequest, { params }:{params:{bookingId:strin
     create: { bookingId: params.bookingId, starsCategory1, starsCategory2, starsCategory3, actions, text, wordCount, extraCategoryRatings, submittedAt: new Date(), qcStatus: 'revise' },
   });
   // Enqueue QC
+  const { enqueueFeedbackQC } = await import('../../../../../lib/queues');
   await enqueueFeedbackQC(params.bookingId);
   return NextResponse.json({ ok: true, feedback: fb });
 }

--- a/src/app/api/qc/[bookingId]/recheck/route.ts
+++ b/src/app/api/qc/[bookingId]/recheck/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
-import { enqueueFeedbackQC } from '../../../../../../lib/queues';
 
 export async function POST(_: Request, { params }:{params:{bookingId:string}}){
+  const { enqueueFeedbackQC } = await import('../../../../../../lib/queues');
   await enqueueFeedbackQC(params.bookingId);
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- Lazily import queue utilities to prevent Redis connection during feedback or QC API route load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b633a054b88325b0d95dd0c291e1c3