### PR TITLE
Lock booking price at request time

### DIFF
--- a/lib/payments/stripe.ts
+++ b/lib/payments/stripe.ts
@@ -17,13 +17,14 @@ export const PLATFORM_FEE = Number(process.env.PLATFORM_FEE || '0');
  */
 export async function createCheckoutIntent(
   bookingId: string,
-  amountUSD: number,
   opts: { takeRate?: number; customerId?: string } = {},
 ) {
   const { takeRate = PLATFORM_FEE, customerId } = opts;
-  const amount = Math.round(amountUSD * 100);
   const booking = await prisma.booking.findUnique({ where: { id: bookingId } });
   if (!booking) throw new Error('booking not found');
+  if (booking.priceUSD == null)
+    throw new Error('booking price not set');
+  const amount = Math.round(booking.priceUSD * 100);
 
   const pi = await stripe.paymentIntents.create({
     amount,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -151,6 +151,7 @@ model Booking {
   status           BookingStatus
   startAt          DateTime
   endAt            DateTime
+  priceUSD         Int?
   zoomMeetingId    String?
   zoomJoinUrl      String?
   calendarEventIds Json          @default("[]")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -195,7 +195,7 @@ async function createProfessionals() {
       education: { create: [randomEducation()] },
     },
   });
-  out.push(euisangss);
+  out.push({ ...euisangss, priceUSD: 100 });
 
   // additional mock professionals
   for (let i = 1; i <= 9; i++) {
@@ -224,7 +224,7 @@ async function createProfessionals() {
         education: { create: [randomEducation()] },
       },
     });
-    out.push(user);
+    out.push({ ...user, priceUSD: 80 + i });
   }
 
   return out;
@@ -288,6 +288,7 @@ async function createBookings(candidates: any[], professionals: any[]) {
         status: BookingStatus.accepted,
         startAt: start,
         endAt: new Date(start.getTime() + 30 * 60 * 1000),
+        priceUSD: professionals[spec.professionalIdx].priceUSD,
         zoomMeetingId: spec.meetingId,
         zoomJoinUrl: spec.joinUrl,
       },
@@ -374,6 +375,7 @@ async function createBookings(candidates: any[], professionals: any[]) {
         status: BookingStatus.completed,
         startAt: start,
         endAt: new Date(start.getTime() + 30 * 60 * 1000),
+        priceUSD: professionals[spec.professionalIdx].priceUSD,
       },
     });
     bookings.push(booking);
@@ -426,6 +428,7 @@ async function createBookings(candidates: any[], professionals: any[]) {
         status: completed ? BookingStatus.completed : BookingStatus.requested,
         startAt: start,
         endAt: new Date(start.getTime() + 30 * 60 * 1000),
+        priceUSD: pro.priceUSD,
       },
     });
     bookings.push(booking);

--- a/src/app/api/bookings/[id]/checkout/route.ts
+++ b/src/app/api/bookings/[id]/checkout/route.ts
@@ -11,20 +11,22 @@ export async function POST(req: NextRequest, { params }:{params:{id:string}}){
   if(!booking || booking.candidateId !== session.user.id) return NextResponse.json({error:'forbidden'}, {status:403});
   const user = await prisma.user.findUnique({ where: { id: session.user.id } });
   if(!user) return NextResponse.json({error:'user_not_found'}, {status:404});
-  const { priceUSD = 40 } = await req.json();
   const customerId = await ensureCustomer(
     user.id,
     user.email,
     `${user.firstName || ''} ${user.lastName || ''}`.trim(),
   );
-
-  const pi = await createCheckoutIntent(booking.id, priceUSD, { customerId });
+  if (booking.priceUSD == null)
+    return NextResponse.json({ error: 'price_missing' }, { status: 500 });
+  const priceUSD = booking.priceUSD;
+  const pi = await createCheckoutIntent(booking.id, { customerId });
   const meeting = await createZoomMeeting('Monet Call', booking.startAt.toISOString());
 
   const updated = await prisma.booking.update({ where: { id: booking.id }, data: {
     status: 'accepted',
     zoomMeetingId: String(meeting.id),
     zoomJoinUrl: meeting.join_url,
+    priceUSD,
   }});
 
   return NextResponse.json({

--- a/src/app/api/bookings/request/route.ts
+++ b/src/app/api/bookings/request/route.ts
@@ -9,7 +9,8 @@ export async function POST(req: NextRequest){
   if(!session?.user) return NextResponse.json({error:'unauthorized'}, {status:401});
   if(!rateLimit(`req:${session.user.id}`)) return NextResponse.json({error:'rate_limited'}, {status:429});
   const body = await req.json();
-  const { professionalId, priceUSD } = body;
+  const { professionalId } = body;
+  const pro = await prisma.professionalProfile.findUnique({ where: { userId: professionalId }, select: { priceUSD: true } });
   const booking = await prisma.booking.create({
     data: {
       candidateId: session.user.id,
@@ -17,6 +18,7 @@ export async function POST(req: NextRequest){
       status: 'requested',
       startAt: new Date(0),
       endAt: new Date(0),
+      priceUSD: pro?.priceUSD ?? 0,
     }
   });
   if(process.env.SMTP_HOST){
@@ -29,5 +31,5 @@ export async function POST(req: NextRequest){
       });
     }
   }
-  return NextResponse.json({ id: booking.id, status: booking.status, priceUSD });
+  return NextResponse.json({ id: booking.id, status: booking.status, priceUSD: booking.priceUSD });
 }


### PR DESCRIPTION
## Summary
- capture professional's rate when a booking request is created
- use stored booking price during checkout
- seed requested bookings with professional price
- derive Stripe payment intent amount from booking's locked price

## Testing
- `npm test`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68b639e605008325aa4e10ae8a2ee748