### PR TITLE
Fix account deletion for candidate and professional settings

### DIFF
--- a/src/app/api/candidate/settings/route.ts
+++ b/src/app/api/candidate/settings/route.ts
@@ -90,7 +90,10 @@ export async function DELETE() {
   const session = await auth();
   if (!session?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   await prisma.user.delete({ where: { id: session.user.id } });
-  await prisma.candidateProfile.delete({ where: { userId: session.user.id } });
+  // CandidateProfile has an onDelete: Cascade relation with User, so deleting the
+  // user will automatically remove the candidate profile. Attempting to delete
+  // it explicitly after the user has been removed results in a "Record to
+  // delete does not exist" error, which caused the delete account button to fail.
   return NextResponse.json({ ok: true });
 }
 

--- a/src/app/api/professional/settings/route.ts
+++ b/src/app/api/professional/settings/route.ts
@@ -45,7 +45,10 @@ export async function DELETE() {
   const session = await auth();
   if (!session?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   await prisma.user.delete({ where: { id: session.user.id } });
-  await prisma.professionalProfile.delete({ where: { userId: session.user.id } });
+  // ProfessionalProfile is linked to User with onDelete: Cascade, so removing the
+  // user automatically removes the professional profile. Trying to delete it
+  // separately after the user has been deleted triggers a "Record to delete does
+  // not exist" error, preventing account deletion.
   return NextResponse.json({ ok: true });
 }
 


### PR DESCRIPTION
## Summary
- prevent explicit deletion of candidate and professional profiles after removing user
- avoid cascading delete errors so "Delete Account" buttons succeed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b648b799a08325b3a7d754a4282d7d