### PR TITLE
Fix account deletion for candidates and professionals

### DIFF
--- a/src/app/api/candidate/settings/route.ts
+++ b/src/app/api/candidate/settings/route.ts
@@ -90,7 +90,6 @@ export async function DELETE() {
   const session = await auth();
   if (!session?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   await prisma.user.delete({ where: { id: session.user.id } });
-  await prisma.candidateProfile.delete({ where: { userId: session.user.id } });
   return NextResponse.json({ ok: true });
 }
 

--- a/src/app/api/professional/settings/route.ts
+++ b/src/app/api/professional/settings/route.ts
@@ -45,7 +45,6 @@ export async function DELETE() {
   const session = await auth();
   if (!session?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   await prisma.user.delete({ where: { id: session.user.id } });
-  await prisma.professionalProfile.delete({ where: { userId: session.user.id } });
   return NextResponse.json({ ok: true });
 }
 


### PR DESCRIPTION
## Summary
- remove redundant profile deletions in account delete endpoints
- rely on cascading user delete for candidate and professional profiles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b648b799a08325b3a7d754a4282d7d