### PR TITLE
Enable cascade deletes for user relations

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -158,8 +158,8 @@ model Booking {
   createdAt        DateTime      @default(now())
   updatedAt        DateTime      @updatedAt
 
-  candidate          User                @relation("CandidateBookings", fields: [candidateId], references: [id])
-  professional       User                @relation("ProfessionalBookings", fields: [professionalId], references: [id])
+  candidate          User                @relation("CandidateBookings", fields: [candidateId], references: [id], onDelete: Cascade)
+  professional       User                @relation("ProfessionalBookings", fields: [professionalId], references: [id], onDelete: Cascade)
   payment            Payment?
   feedback           Feedback?
   professionalReview ProfessionalReview?
@@ -276,7 +276,7 @@ model AuditLog {
   metadata    Json     @default("{}")
   createdAt   DateTime @default(now())
 
-  actor User? @relation("AuditActor", fields: [actorUserId], references: [id])
+  actor User? @relation("AuditActor", fields: [actorUserId], references: [id], onDelete: Cascade)
 }
 
 // Postgres view for listing cards


### PR DESCRIPTION
## Summary
- cascade delete bookings tied to a user
- cascade delete audit logs referencing a user

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b677dde5808325842a46fec28d0cb2