### PR TITLE
Add dedicated Stripe payment step before booking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@aws-sdk/s3-request-presigner": "^3.876.0",
         "@prisma/client": "^6.14.0",
         "@prisma/extension-accelerate": "^2.0.2",
+        "@stripe/react-stripe-js": "^3.9.2",
+        "@stripe/stripe-js": "^7.9.0",
         "@toast-ui/calendar": "^2.0.1",
         "bcryptjs": "^2.4.3",
         "bullmq": "^5.7.6",
@@ -2936,6 +2938,29 @@
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.9.2.tgz",
+      "integrity": "sha512-urAZek4LrnHWfk4WYXItOiX+6xyxjcn0SkhBDoysXphLkUt92UWCd5+NlomhVqaLo98XiUQGZRiRcL8HOHZ8Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=1.44.1 <8.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.9.0.tgz",
+      "integrity": "sha512-ggs5k+/0FUJcIgNY08aZTqpBTtbExkJMYMLSMwyucrhtWexVOEY1KJmhBsxf+E/Q15f5rbwBpj+t0t2AW2oCsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@aws-sdk/s3-request-presigner": "^3.876.0",
     "@prisma/client": "^6.14.0",
     "@prisma/extension-accelerate": "^2.0.2",
+    "@stripe/react-stripe-js": "^3.9.2",
+    "@stripe/stripe-js": "^7.9.0",
     "@toast-ui/calendar": "^2.0.1",
     "bcryptjs": "^2.4.3",
     "bullmq": "^5.7.6",

--- a/src/app/api/stripe/intent/route.ts
+++ b/src/app/api/stripe/intent/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../../../lib/db';
+import { stripe, ensureCustomer } from '../../../../../lib/payments/stripe';
+import { auth } from '@/auth';
+
+export async function POST(req: NextRequest) {
+  const session = await auth();
+  if (!session?.user)
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const { professionalId } = await req.json();
+  if (!professionalId)
+    return NextResponse.json({ error: 'missing_professional' }, { status: 400 });
+
+  const pro = await prisma.professionalProfile.findUnique({
+    where: { userId: professionalId },
+    select: { priceUSD: true },
+  });
+  if (!pro?.priceUSD)
+    return NextResponse.json({ error: 'price_missing' }, { status: 400 });
+
+  const user = await prisma.user.findUnique({ where: { id: session.user.id } });
+  if (!user)
+    return NextResponse.json({ error: 'user_not_found' }, { status: 404 });
+
+  const customerId = await ensureCustomer(
+    user.id,
+    user.email,
+    `${user.firstName || ''} ${user.lastName || ''}`.trim(),
+  );
+
+  const pi = await stripe.paymentIntents.create({
+    amount: Math.round(pro.priceUSD * 100),
+    currency: 'usd',
+    automatic_payment_methods: { enabled: true },
+    customer: customerId,
+    metadata: { professionalId },
+  });
+
+  return NextResponse.json({
+    clientSecret: (pi as any).client_secret,
+    paymentIntentId: pi.id,
+  });
+}
+

--- a/src/app/candidate/detail/[id]/schedule/checkout/page.tsx
+++ b/src/app/candidate/detail/[id]/schedule/checkout/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { loadStripe } from "@stripe/stripe-js";
+import {
+  Elements,
+  PaymentElement,
+  useElements,
+  useStripe,
+} from "@stripe/react-stripe-js";
+import { Card, Button } from "../../../../../components/ui";
+import { ProfessionalResponse } from "../types";
+
+const stripePromise = loadStripe(
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || ""
+);
+
+function CheckoutForm({
+  professionalId,
+  slots,
+  weeks,
+}: {
+  professionalId: string;
+  slots: any[];
+  weeks: number;
+}) {
+  const stripe = useStripe();
+  const elements = useElements();
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!stripe || !elements) return;
+
+    const { error, paymentIntent } = await stripe.confirmPayment({
+      elements,
+      redirect: "if_required",
+    });
+    if (error) {
+      window.alert(error.message || "Payment failed");
+      return;
+    }
+    if (paymentIntent?.status === "succeeded") {
+      const res = await fetch("/api/bookings/request", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ professionalId, slots, weeks }),
+      });
+      if (res.ok) {
+        window.alert("Your booking request has been sent.");
+        router.push("/candidate/dashboard");
+      }
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="col" style={{ gap: 16 }}>
+      <PaymentElement />
+      <Button type="submit" disabled={!stripe}>
+        Pay
+      </Button>
+    </form>
+  );
+}
+
+export default function CheckoutPage({ params }: { params: { id: string } }) {
+  const searchParams = useSearchParams();
+  const slots = JSON.parse(searchParams.get("slots") || "[]");
+  const weeks = parseInt(searchParams.get("weeks") || "2");
+  const [clientSecret, setClientSecret] = useState<string | null>(null);
+  const [pro, setPro] = useState<ProfessionalResponse | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/professionals/${params.id}`).then(async (res) => {
+      if (res.ok) {
+        const data: ProfessionalResponse = await res.json();
+        setPro(data);
+      }
+    });
+  }, [params.id]);
+
+  useEffect(() => {
+    fetch("/api/stripe/intent", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ professionalId: params.id }),
+    })
+      .then((res) => res.json())
+      .then((data) => setClientSecret(data.clientSecret));
+  }, [params.id]);
+
+  if (!clientSecret) return <p>Loading...</p>;
+
+  return (
+    <Elements stripe={stripePromise} options={{ clientSecret }}>
+      <div className="col" style={{ gap: 16 }}>
+        {pro && (
+          <Card className="col" style={{ padding: 16, gap: 8 }}>
+            <p>
+              You are booking a 30 minute chat with {pro.title} at {pro.employer}.
+            </p>
+            <p>The professional will only be paid once they provide feedback.</p>
+          </Card>
+        )}
+        <CheckoutForm
+          professionalId={params.id}
+          slots={slots}
+          weeks={weeks}
+        />
+      </div>
+    </Elements>
+  );
+}
+

--- a/src/app/candidate/detail/[id]/schedule/page.tsx
+++ b/src/app/candidate/detail/[id]/schedule/page.tsx
@@ -1,17 +1,19 @@
-'use client';
-import { useState } from 'react';
-import AvailabilityCalendar from '../../../../../components/AvailabilityCalendar';
-import { Card, Input } from '../../../../../components/ui';
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import AvailabilityCalendar from "../../../../../components/AvailabilityCalendar";
+import { Card, Input } from "../../../../../components/ui";
 
 export default function Schedule({ params }: { params: { id: string } }) {
   const [weeks, setWeeks] = useState(2);
+  const router = useRouter();
 
-  const handleConfirm = async (slots: any[]) => {
-    await fetch('/api/bookings/request', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ professionalId: params.id, slots, weeks }),
+  const handleConfirm = (slots: any[]) => {
+    const qs = new URLSearchParams({
+      slots: JSON.stringify(slots),
+      weeks: String(weeks),
     });
+    router.push(`/candidate/detail/${params.id}/schedule/checkout?${qs.toString()}`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- Redirect scheduling flow to a Stripe checkout page before booking
- Capture payment and create booking request after successful charge
- Add API endpoint for creating Stripe PaymentIntents
- Move payment intent API under existing Stripe routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6b22d686c832590f32bfee34c8f0b