### PR TITLE
feat: handle professional booking responses

### DIFF
--- a/src/app/api/bookings/[id]/decline/route.ts
+++ b/src/app/api/bookings/[id]/decline/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../../../../lib/db';
+import { auth } from '@/auth';
+
+export async function POST(_req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await auth();
+  if (!session?.user) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const booking = await prisma.booking.findUnique({ where: { id: params.id } });
+  if (!booking || booking.professionalId !== session.user.id) {
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+  }
+  await prisma.booking.update({ where: { id: booking.id }, data: { status: 'cancelled' } });
+  return NextResponse.json({ status: 'cancelled' });
+}

--- a/src/app/api/bookings/[id]/schedule/route.ts
+++ b/src/app/api/bookings/[id]/schedule/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '../../../../../../lib/db';
 import { CALL_DURATION_MINUTES } from '../../../../../../lib/flags';
 import { auth } from '@/auth';
+import { createZoomMeeting } from '../../../../../../lib/zoom';
+import { mailer } from '../../../../../../lib/email';
 
 export async function POST(req: NextRequest, { params }:{params:{id:string}}){
   const session = await auth();
@@ -11,6 +13,40 @@ export async function POST(req: NextRequest, { params }:{params:{id:string}}){
   if(!booking || booking.professionalId !== session.user.id) return NextResponse.json({error:'forbidden'}, {status:403});
   const start = new Date(startAt);
   const end = new Date(start.getTime() + CALL_DURATION_MINUTES*60*1000);
-  const updated = await prisma.booking.update({ where: { id: booking.id }, data: { startAt: start, endAt: end, status: 'accepted' } });
+  const zoom = await createZoomMeeting('Mentorship Call', start.toISOString());
+  const updated = await prisma.booking.update({
+    where: { id: booking.id },
+    data: {
+      startAt: start,
+      endAt: end,
+      status: 'accepted',
+      zoomMeetingId: zoom.id,
+      zoomJoinUrl: zoom.join_url,
+    },
+  });
+
+  if (process.env.SMTP_HOST) {
+    const users = await prisma.user.findMany({
+      where: { id: { in: [booking.professionalId, booking.candidateId] } },
+      select: { id: true, email: true },
+    });
+    const proEmail = users.find((u) => u.id === booking.professionalId)?.email;
+    const candEmail = users.find((u) => u.id === booking.candidateId)?.email;
+    const formatICS = (d: Date) =>
+      d.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+    const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:${updated.id}\nDTSTAMP:${formatICS(
+      new Date()
+    )}\nDTSTART:${formatICS(start)}\nDTEND:${formatICS(end)}\nSUMMARY:Mentorship Call\nDESCRIPTION:Join Zoom meeting at ${zoom.join_url}\nURL:${zoom.join_url}\nEND:VEVENT\nEND:VCALENDAR`;
+    const recipients = [proEmail, candEmail].filter(Boolean).join(',');
+    if (recipients) {
+      await mailer.sendMail({
+        to: recipients,
+        subject: 'Call Confirmed',
+        text: `Join Zoom meeting: ${zoom.join_url}`,
+        icalEvent: { method: 'REQUEST', filename: 'invite.ics', content: ics },
+      });
+    }
+  }
+
   return NextResponse.json({ id: updated.id, startAt: updated.startAt, endAt: updated.endAt, status: updated.status });
 }

--- a/src/app/professional/requests/[id]/page.tsx
+++ b/src/app/professional/requests/[id]/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+import React, { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import AvailabilityCalendar, { Slot } from "../../../../components/AvailabilityCalendar";
+
+export default function RequestSchedule({ params }: { params: { id: string } }) {
+  const [slots, setSlots] = useState<Slot[]>([]);
+  const router = useRouter();
+
+  useEffect(() => {
+    fetch(`/api/bookings/${params.id}/accept`, { method: "POST" })
+      .then((res) => res.json())
+      .then((data) => {
+        const availability: Slot[] = (data.availability || []).map((s: any) => ({
+          start: s.startAt,
+          end: s.endAt,
+        }));
+        setSlots(availability);
+      });
+  }, [params.id]);
+
+  const handleConfirm = async (selected: Slot[]) => {
+    if (!selected[0]) return;
+    await fetch(`/api/bookings/${params.id}/schedule`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ startAt: selected[0].start }),
+    });
+    router.push("/professional/requests");
+  };
+
+  return (
+    <div className="col" style={{ gap: 16 }}>
+      <p>Please choose from the blue cells below.</p>
+      <AvailabilityCalendar
+        mode="select"
+        slots={slots}
+        onConfirm={handleConfirm}
+        confirmText="Confirm Booking"
+      />
+    </div>
+  );
+}

--- a/src/app/professional/requests/page.tsx
+++ b/src/app/professional/requests/page.tsx
@@ -1,6 +1,6 @@
-import Link from "next/link";
 import DashboardClient from "../../../components/DashboardClient";
-import { Button, Badge } from "../../../components/ui";
+import { Badge } from "../../../components/ui";
+import RequestActions from "../../../components/RequestActions";
 import { auth } from "@/auth";
 import { getProfessionalRequests } from "../../api/professional/requests";
 
@@ -42,13 +42,7 @@ export default async function Requests({
       </div>
     );
     const action = (
-      <div className="row" style={{ gap: 8, flexWrap: "wrap" }}>
-        <Button style={{ backgroundColor: "green", color: "white" }}>Accept</Button>
-        <Button variant="danger">Reject</Button>
-        <Link href={`/candidate/detail/${candidate.id}`}>
-          <Button variant="primary">View Details</Button>
-        </Link>
-      </div>
+      <RequestActions bookingId={r.id} candidateId={candidate.id} />
     );
     return { name, school, interests, activities, action };
   });

--- a/src/components/AvailabilityCalendar.tsx
+++ b/src/components/AvailabilityCalendar.tsx
@@ -5,7 +5,7 @@ import { Button } from './ui';
 import { addMinutes, addDays, startOfWeek, format } from 'date-fns';
 import { signIn } from 'next-auth/react';
 
-type Slot = {
+export type Slot = {
   start: string;
   end: string;
 };
@@ -13,32 +13,58 @@ type Slot = {
 interface AvailabilityCalendarProps {
   weeks?: number;
   onConfirm?: (slots: Slot[]) => void;
+  /**
+   * edit – candidate selecting their availability
+   * select – professional choosing one of the candidate's slots
+   */
+  mode?: 'edit' | 'select';
+  /** preset slots for select mode */
+  slots?: Slot[];
+  /** text for the confirm button in select mode */
+  confirmText?: string;
 }
 
-const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ weeks = 2, onConfirm }) => {
-  const [events, setEvents] = useState<Slot[]>([]);
+const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({
+  weeks = 2,
+  onConfirm,
+  mode = 'edit',
+  slots = [],
+  confirmText = 'Confirm Booking',
+}) => {
+  const isEdit = mode === 'edit';
+  const [events, setEvents] = useState<Slot[]>(isEdit ? [] : slots);
   const [busyEvents, setBusyEvents] = useState<Slot[]>([]);
   const [defaultBusy, setDefaultBusy] = useState<Slot[]>([]);
   const [defaultBusyRanges, setDefaultBusyRanges] = useState<{ day: number; start: string; end: string }[]>([]);
   const [weekStart, setWeekStart] = useState(startOfWeek(new Date(), { weekStartsOn: 0 }));
   const [isDragging, setIsDragging] = useState(false);
   const draggedSlots = useRef<Set<number>>(new Set());
+  const [selected, setSelected] = useState<Slot | null>(null);
+
+  useEffect(() => {
+    if (!isEdit) setEvents(slots);
+  }, [slots, isEdit]);
 
   const handleConfirm = async () => {
-    const end = addDays(new Date(), weeks * 7);
-    const filtered = events.filter(e => new Date(e.start) < end);
-    if (onConfirm) {
-      await onConfirm(filtered);
-    } else {
-      await fetch('/api/candidate/availability', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ events: filtered, busy: [...busyEvents, ...defaultBusy] }),
-      });
+    if (isEdit) {
+      const end = addDays(new Date(), weeks * 7);
+      const filtered = events.filter(e => new Date(e.start) < end);
+      if (onConfirm) {
+        await onConfirm(filtered);
+      } else {
+        await fetch('/api/candidate/availability', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ events: filtered, busy: [...busyEvents, ...defaultBusy] }),
+        });
+      }
+    } else if (onConfirm && selected) {
+      await onConfirm([selected]);
     }
   };
 
   const handleSync = async () => {
+    if (!isEdit) return;
     const res = await fetch('/api/candidate/busy');
     if(res.status === 401){
       alert('Please connect your Google Calendar to sync availability.');
@@ -61,6 +87,7 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ weeks = 2, 
   };
 
   useEffect(() => {
+    if (!isEdit) return;
     const load = async () => {
       const saved = localStorage.getItem('candidateAvailability');
       if (saved) {
@@ -75,17 +102,20 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ weeks = 2, 
       }
     };
     load();
-  }, []);
+  }, [isEdit]);
 
   useEffect(() => {
+    if (!isEdit) return;
     localStorage.setItem('candidateAvailability', JSON.stringify(events));
-  }, [events]);
+  }, [events, isEdit]);
 
   useEffect(() => {
+    if (!isEdit) return;
     handleSync();
-  }, []);
+  }, [isEdit]);
 
   useEffect(() => {
+    if (!isEdit) return;
     async function loadDefaults() {
       try {
         const res = await fetch('/api/candidate/settings');
@@ -98,9 +128,10 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ weeks = 2, 
       }
     }
     loadDefaults();
-  }, []);
+  }, [isEdit]);
 
   useEffect(() => {
+    if (!isEdit) return;
     const base = startOfWeek(weekStart, { weekStartsOn: 0 });
     const slots: Slot[] = [];
     for (let w = 0; w < weeks; w++) {
@@ -120,7 +151,7 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ weeks = 2, 
       });
     }
     setDefaultBusy(slots);
-  }, [weekStart, weeks, defaultBusyRanges]);
+  }, [weekStart, weeks, defaultBusyRanges, isEdit]);
 
   useEffect(() => {
     const handleMouseUp = () => {
@@ -135,12 +166,14 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ weeks = 2, 
   const times = Array.from({ length: 48 }, (_, i) => addMinutes(weekStart, i * 30));
 
   const isBusy = (date: Date) => {
+    if (!isEdit) return false;
     const all = [...busyEvents, ...defaultBusy];
     return all.some(e => new Date(e.start).getTime() === date.getTime());
   };
   const isAvailable = (date: Date) => events.some(e => new Date(e.start).getTime() === date.getTime());
 
   const toggleSlot = (date: Date) => {
+    if (!isEdit) return;
     const startIso = date.toISOString();
     const endIso = new Date(date.getTime() + 30 * 60 * 1000).toISOString();
 
@@ -167,8 +200,8 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ weeks = 2, 
       <div className="row" style={{ gap: 8 }}>
         <Button onClick={prevWeek}>{'<'}</Button>
         <Button onClick={nextWeek}>{'>'}</Button>
-        <Button onClick={handleSync}>Sync Google Calendar</Button>
-        <Button onClick={handleConfirm}>Confirm Availability</Button>
+        {isEdit && <Button onClick={handleSync}>Sync Google Calendar</Button>}
+        {isEdit && <Button onClick={handleConfirm}>Confirm Availability</Button>}
       </div>
       <div
         className="calendar-grid"
@@ -217,16 +250,22 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ weeks = 2, 
               const busy = isBusy(slotStart);
               const available = isAvailable(slotStart);
               const key = slotStart.getTime();
+              const startIso = slotStart.toISOString();
+              const isSelected = selected && selected.start === startIso;
               return (
                 <div
                   key={`${col}-${row}`}
                   onMouseDown={() => {
-                    toggleSlot(slotStart);
-                    setIsDragging(true);
-                    draggedSlots.current = new Set([key]);
+                    if (isEdit) {
+                      toggleSlot(slotStart);
+                      setIsDragging(true);
+                      draggedSlots.current = new Set([key]);
+                    } else if (available) {
+                      setSelected({ start: startIso, end: new Date(slotStart.getTime() + 30 * 60 * 1000).toISOString() });
+                    }
                   }}
                   onMouseEnter={() => {
-                    if (isDragging && !draggedSlots.current.has(key)) {
+                    if (isEdit && isDragging && !draggedSlots.current.has(key)) {
                       toggleSlot(slotStart);
                       draggedSlots.current.add(key);
                     }
@@ -234,8 +273,16 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ weeks = 2, 
                   style={{
                     borderTop: '1px solid var(--border)',
                     borderLeft: '1px solid var(--border)',
-                    background: busy || available ? '#f87171' : 'transparent',
-                    cursor: 'pointer',
+                    background: isEdit
+                      ? busy || available
+                        ? '#f87171'
+                        : 'transparent'
+                      : isSelected
+                      ? 'lightgreen'
+                      : available
+                      ? 'lightblue'
+                      : 'transparent',
+                    cursor: isEdit ? 'pointer' : available ? 'pointer' : 'default',
                   }}
                 />
               );
@@ -243,6 +290,11 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({ weeks = 2, 
           </React.Fragment>
         ))}
       </div>
+      {!isEdit && onConfirm && (
+        <Button onClick={handleConfirm} disabled={!selected}>
+          {confirmText}
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/components/RequestActions.tsx
+++ b/src/components/RequestActions.tsx
@@ -1,0 +1,29 @@
+'use client';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { Button } from './ui';
+
+export default function RequestActions({ bookingId, candidateId }: { bookingId: string; candidateId: string }) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  const decline = async () => {
+    setLoading(true);
+    await fetch(`/api/bookings/${bookingId}/decline`, { method: 'POST' });
+    setLoading(false);
+    router.refresh();
+  };
+
+  return (
+    <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
+      <Link href={`/professional/requests/${bookingId}`}>
+        <Button style={{ backgroundColor: 'green', color: 'white' }}>Accept</Button>
+      </Link>
+      <Button variant="danger" onClick={decline} disabled={loading}>Reject</Button>
+      <Link href={`/candidate/detail/${candidateId}`}>
+        <Button variant="primary">View Details</Button>
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow professionals to accept or reject booking requests with new RequestActions component
- add calendar selection page to pick a 30‑minute slot and schedule calls
- create Zoom meeting, send calendar invite, and mark declined requests as cancelled
- reuse AvailabilityCalendar for professionals selecting candidate slots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7b1e78a3c8325a8f7b2a2593e81b2