### PR TITLE
feat: update booking status when both join

### DIFF
--- a/lib/zoom.ts
+++ b/lib/zoom.ts
@@ -1,4 +1,5 @@
-import { CALL_DURATION_MINUTES } from './flags';
+import { BookingStatus } from '@prisma/client';
+import { prisma } from './db';
 
 export async function createZoomMeeting(topic: string, startIso: string){
   // Server-to-Server OAuth access token would be retrieved via JWT or OAuth.
@@ -17,4 +18,47 @@ export async function createZoomMeeting(topic: string, startIso: string){
   return {
     id, join_url: `https://zoom.us/j/${id}`, start_time: startIso, passcode: '123456',
   };
+}
+
+export async function recordZoomJoin(
+  zoomMeetingId: string,
+  participantEmail: string,
+  db = prisma,
+){
+  const booking = await db.booking.findFirst({
+    where: { zoomMeetingId },
+    include: {
+      candidate: { select: { email: true } },
+      professional: { select: { email: true } },
+    },
+  });
+  if (!booking) return;
+
+  const email = participantEmail.toLowerCase();
+  const data: Record<string, Date> = {};
+  if (
+    email === booking.candidate.email.toLowerCase() &&
+    !booking.candidateJoinedAt
+  ) {
+    data.candidateJoinedAt = new Date();
+  }
+  if (
+    email === booking.professional.email.toLowerCase() &&
+    !booking.professionalJoinedAt
+  ) {
+    data.professionalJoinedAt = new Date();
+  }
+  if (Object.keys(data).length === 0) return;
+
+  const updated = await db.booking.update({ where: { id: booking.id }, data });
+  if (
+    updated.candidateJoinedAt &&
+    updated.professionalJoinedAt &&
+    updated.status !== BookingStatus.completed_pending_feedback
+  ) {
+    await db.booking.update({
+      where: { id: booking.id },
+      data: { status: BookingStatus.completed_pending_feedback },
+    });
+  }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -154,6 +154,8 @@ model Booking {
   priceUSD         Int?
   zoomMeetingId    String?
   zoomJoinUrl      String?
+  candidateJoinedAt    DateTime?
+  professionalJoinedAt DateTime?
   calendarEventIds Json          @default("[]")
   createdAt        DateTime      @default(now())
   updatedAt        DateTime      @updatedAt

--- a/tests/zoom.test.ts
+++ b/tests/zoom.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { recordZoomJoin } from '../lib/zoom';
+import { BookingStatus } from '@prisma/client';
+
+describe('recordZoomJoin', () => {
+  it('sets booking to completed_pending_feedback once both join', async () => {
+    const booking = {
+      id: 'b1',
+      candidate: { email: 'cand@example.com' },
+      professional: { email: 'pro@example.com' },
+      status: BookingStatus.accepted,
+      candidateJoinedAt: null as Date | null,
+      professionalJoinedAt: null as Date | null,
+    };
+    const prismaMock = {
+      booking: {
+        findFirst: async () => booking,
+        update: async ({ data }: any) => {
+          Object.assign(booking, data);
+          return booking;
+        },
+      },
+    };
+
+    await recordZoomJoin('m1', 'cand@example.com', prismaMock as any);
+    expect(booking.status).toBe(BookingStatus.accepted);
+    expect(booking.candidateJoinedAt).toBeInstanceOf(Date);
+
+    await recordZoomJoin('m1', 'pro@example.com', prismaMock as any);
+    expect(booking.professionalJoinedAt).toBeInstanceOf(Date);
+    expect(booking.status).toBe(BookingStatus.completed_pending_feedback);
+  });
+});


### PR DESCRIPTION
## Summary
- track when candidate and professional join a Zoom meeting
- auto-mark bookings as completed_pending_feedback once both participants join
- add unit test verifying status update after both join

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8417baa108325830968d71d5e87ed