### PR TITLE
Fix sign-out redirect to avoid 404

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,9 +1,10 @@
 'use server';
 
 import { signOut } from '@/auth';
+import { redirect } from 'next/navigation';
 
 export async function signOutAction() {
-  // await signOut({ redirectTo: '/' });
-  return await signOut({ redirectTo: '/' });
+  await signOut({ redirect: false });
+  redirect('/');
 }
 


### PR DESCRIPTION
## Summary
- adjust sign-out server action to perform redirect explicitly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f68545808325ae8aa84daf7d7fe2