### PR TITLE
Fix verification status on professional settings

### DIFF
--- a/src/app/api/professional/settings.ts
+++ b/src/app/api/professional/settings.ts
@@ -8,6 +8,7 @@ export async function getProfessionalSettings(userId: string) {
       firstName: true,
       lastName: true,
       flags: true,
+      corporateEmailVerified: true,
       professionalProfile: { select: { verifiedAt: true } },
     },
   });
@@ -16,7 +17,8 @@ export async function getProfessionalSettings(userId: string) {
   const fullName = [user.firstName, user.lastName].filter(Boolean).join(" ");
   const flags = (user.flags as any) || {};
   const timezone = flags.timezone || "";
-  const verified = !!user.professionalProfile?.verifiedAt;
+  const verified =
+    user.corporateEmailVerified || !!user.professionalProfile?.verifiedAt;
 
   return {
     email: user.email,

--- a/src/app/api/professional/settings/route.ts
+++ b/src/app/api/professional/settings/route.ts
@@ -10,7 +10,8 @@ async function fetchSettings(userId: string) {
   if (!user) return null;
   const flags: any = user.flags || {};
   const timezone = flags.timezone || '';
-  const verified = !!user.professionalProfile?.verifiedAt;
+  const verified =
+    user.corporateEmailVerified || !!user.professionalProfile?.verifiedAt;
   const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ');
   return { name: fullName, email: user.email, timezone, verified };
 }


### PR DESCRIPTION
## Summary
- Ensure professional settings verification status reflects corporate email verification by checking `corporateEmailVerified`
- Include corporate email verification flag when retrieving professional settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bae1788f4c8325bc7bf0401a6c5509