### PR TITLE
Add candidate detail page and shared profile component

### DIFF
--- a/src/app/api/candidate/[id]/route.ts
+++ b/src/app/api/candidate/[id]/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { prisma } from '../../../../../lib/db';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const user = await prisma.user.findUnique({
+    where: { id: params.id },
+    include: {
+      candidateProfile: {
+        include: { experience: true, education: true },
+      },
+    },
+  });
+  const profile = user?.candidateProfile;
+  if (!user || !profile) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+  const payload: any = {
+    identity: {
+      name: `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() || undefined,
+      email: user.email,
+    },
+    resumeUrl: profile.resumeUrl,
+    interests: profile.interests,
+    activities: profile.activities,
+    experience: profile.experience.map((e) => ({
+      firm: e.firm,
+      title: e.title,
+      startDate: e.startDate,
+      endDate: e.endDate,
+    })),
+    education: profile.education.map((e) => ({
+      school: e.school,
+      title: e.title,
+      startDate: e.startDate,
+      endDate: e.endDate,
+    })),
+  };
+  return NextResponse.json(payload);
+}

--- a/src/app/candidate/detail/[id]/page.tsx
+++ b/src/app/candidate/detail/[id]/page.tsx
@@ -1,5 +1,5 @@
-import DetailClient from './DetailClient';
-import { ProfessionalResponse } from './types';
+import ProfileDetail from '../../../../components/ProfileDetail';
+import { ProfileResponse } from '../../../../types/profile';
 
 export default async function Detail({ params }: { params: { id: string } }) {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
@@ -9,6 +9,11 @@ export default async function Detail({ params }: { params: { id: string } }) {
   if (!res.ok) {
     throw new Error('Failed to load professional profile');
   }
-  const pro: ProfessionalResponse = await res.json();
-  return <DetailClient pro={pro} proId={params.id} />;
+  const profile: ProfileResponse = await res.json();
+  return (
+    <ProfileDetail
+      profile={profile}
+      schedulePath={`/candidate/detail/${params.id}/schedule`}
+    />
+  );
 }

--- a/src/app/candidate/detail/[id]/schedule/checkout/page.tsx
+++ b/src/app/candidate/detail/[id]/schedule/checkout/page.tsx
@@ -10,7 +10,7 @@ import {
   useStripe,
 } from "@stripe/react-stripe-js";
 import { Card, Button } from "../../../../../../components/ui";
-import { ProfessionalResponse } from "../../types";
+import { ProfileResponse } from "../../../../../../types/profile";
 
 const stripePromise = loadStripe(
   process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || ""
@@ -69,12 +69,12 @@ export default function CheckoutPage({ params }: { params: { id: string } }) {
   const slots = JSON.parse(searchParams.get("slots") || "[]");
   const weeks = parseInt(searchParams.get("weeks") || "2");
   const [clientSecret, setClientSecret] = useState<string | null>(null);
-  const [pro, setPro] = useState<ProfessionalResponse | null>(null);
+  const [pro, setPro] = useState<ProfileResponse | null>(null);
 
   useEffect(() => {
     fetch(`/api/professionals/${params.id}`).then(async (res) => {
       if (res.ok) {
-        const data: ProfessionalResponse = await res.json();
+        const data: ProfileResponse = await res.json();
         setPro(data);
       }
     });

--- a/src/app/professional/detail/[id]/page.tsx
+++ b/src/app/professional/detail/[id]/page.tsx
@@ -1,0 +1,17 @@
+import { headers } from 'next/headers';
+import ProfileDetail from '../../../../components/ProfileDetail';
+import { ProfileResponse } from '../../../../types/profile';
+
+export default async function Detail({ params }: { params: { id: string } }) {
+  const headersList = headers();
+  const host = headersList.get('host') || 'localhost:3000';
+  const protocol = headersList.get('x-forwarded-proto') ?? 'http';
+  const res = await fetch(`${protocol}://${host}/api/candidate/${params.id}`, {
+    cache: 'no-store',
+  });
+  if (!res.ok) {
+    throw new Error('Failed to load candidate profile');
+  }
+  const profile: ProfileResponse = await res.json();
+  return <ProfileDetail profile={profile} />;
+}

--- a/src/components/ProfileDetail.tsx
+++ b/src/components/ProfileDetail.tsx
@@ -4,19 +4,19 @@ import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import clsx from 'clsx';
-import { Button, Card, Badge } from '../../../../components/ui';
-import { ProfessionalResponse } from './types';
+import { Button, Card, Badge } from './ui';
+import { ProfileResponse } from '../types/profile';
 
-export default function DetailClient({ pro, proId }: { pro: ProfessionalResponse; proId: string }) {
+export default function ProfileDetail({
+  profile,
+  schedulePath,
+}: {
+  profile: ProfileResponse;
+  schedulePath?: string;
+}) {
   const [tab, setTab] = useState<'about' | 'reviews'>('about');
-  const name = pro.identity.redacted ? undefined : pro.identity.name;
-  const heading = name ?? `${pro.title} at ${pro.employer}`;
-  const activeStyle = {
-    background: 'var(--gray-900)',
-    color: 'white',
-    cursor: 'pointer',
-  } as const;
-  const inactiveStyle = { cursor: 'pointer' } as const;
+  const name = profile.identity?.redacted ? undefined : profile.identity?.name;
+  const heading = name ?? (profile.title && profile.employer ? `${profile.title} at ${profile.employer}` : undefined);
 
   return (
     <section className="col" style={{ gap: 16 }}>
@@ -35,28 +35,26 @@ export default function DetailClient({ pro, proId }: { pro: ProfessionalResponse
           </div>
           <div className="col" style={{ gap: 4 }}>
             {heading && <h2>{heading}</h2>}
-            <span>{`Price per Session: $${pro.priceUSD}`}</span>
+            {profile.priceUSD !== undefined && (
+              <span>{`Price per Session: $${profile.priceUSD}`}</span>
+            )}
             <div className="row" style={{ alignItems: 'center', gap: 8 }}>
-              {pro.verified && <Badge>Verified Expert</Badge>}
+              {profile.verified && <Badge>Verified Expert</Badge>}
             </div>
           </div>
         </div>
-        <Link href={`/candidate/detail/${proId}/schedule`}>
-          <Button>Schedule a Call</Button>
-        </Link>
+        {schedulePath && (
+          <Link href={schedulePath}>
+            <Button>Schedule a Call</Button>
+          </Link>
+        )}
       </div>
 
       <div className="tabs">
-        <button
-          className={clsx('tab', { active: tab === 'about' })}
-          onClick={() => setTab('about')}
-        >
+        <button className={clsx('tab', { active: tab === 'about' })} onClick={() => setTab('about')}>
           About
         </button>
-        <button
-          className={clsx('tab', { active: tab === 'reviews' })}
-          onClick={() => setTab('reviews')}
-        >
+        <button className={clsx('tab', { active: tab === 'reviews' })} onClick={() => setTab('reviews')}>
           Reviews
         </button>
       </div>
@@ -65,8 +63,8 @@ export default function DetailClient({ pro, proId }: { pro: ProfessionalResponse
         <Card className="col" style={{ padding: 16, gap: 24 }}>
           <div className="col" style={{ gap: 8 }}>
             <h3>Summary</h3>
-            {pro.bio ? (
-              <p>{pro.bio}</p>
+            {profile.bio ? (
+              <p>{profile.bio}</p>
             ) : (
               <p style={{ color: 'var(--text-muted)' }}>No information available</p>
             )}
@@ -74,9 +72,9 @@ export default function DetailClient({ pro, proId }: { pro: ProfessionalResponse
 
           <div className="col" style={{ gap: 8 }}>
             <h3>Experience</h3>
-            {pro.experience && pro.experience.length > 0 ? (
+            {profile.experience && profile.experience.length > 0 ? (
               <ul>
-                {pro.experience.map((item, idx) => {
+                {profile.experience.map((item, idx) => {
                   const period =
                     item.startDate && item.endDate
                       ? `${new Date(item.startDate).getFullYear()}-${new Date(item.endDate).getFullYear()}`
@@ -96,9 +94,9 @@ export default function DetailClient({ pro, proId }: { pro: ProfessionalResponse
 
           <div className="col" style={{ gap: 8 }}>
             <h3>Education</h3>
-            {pro.education && pro.education.length > 0 ? (
+            {profile.education && profile.education.length > 0 ? (
               <ul>
-                {pro.education.map((item, idx) => {
+                {profile.education.map((item, idx) => {
                   const period =
                     item.startDate && item.endDate
                       ? `${new Date(item.startDate).getFullYear()}-${new Date(item.endDate).getFullYear()}`
@@ -118,9 +116,9 @@ export default function DetailClient({ pro, proId }: { pro: ProfessionalResponse
 
           <div className="col" style={{ gap: 8 }}>
             <h3>Interests</h3>
-            {pro.interests && pro.interests.length > 0 ? (
+            {profile.interests && profile.interests.length > 0 ? (
               <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
-                {pro.interests.map((interest) => (
+                {profile.interests.map((interest) => (
                   <Badge key={interest}>{interest}</Badge>
                 ))}
               </div>
@@ -131,9 +129,9 @@ export default function DetailClient({ pro, proId }: { pro: ProfessionalResponse
 
           <div className="col" style={{ gap: 8 }}>
             <h3>Activities</h3>
-            {pro.activities && pro.activities.length > 0 ? (
+            {profile.activities && profile.activities.length > 0 ? (
               <div className="row" style={{ gap: 8, flexWrap: 'wrap' }}>
-                {pro.activities.map((activity) => (
+                {profile.activities.map((activity) => (
                   <Badge key={activity}>{activity}</Badge>
                 ))}
               </div>
@@ -144,8 +142,8 @@ export default function DetailClient({ pro, proId }: { pro: ProfessionalResponse
         </Card>
       ) : (
         <Card className="col" style={{ padding: 16, gap: 16 }}>
-          {pro.reviews && pro.reviews.length > 0 ? (
-            pro.reviews.map((r, idx) => (
+          {profile.reviews && profile.reviews.length > 0 ? (
+            profile.reviews.map((r, idx) => (
               <div key={idx} className="col" style={{ gap: 4 }}>
                 <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
                   <strong>{r.candidate}</strong>

--- a/src/components/RequestActions.tsx
+++ b/src/components/RequestActions.tsx
@@ -21,7 +21,7 @@ export default function RequestActions({ bookingId, candidateId }: { bookingId: 
         <Button style={{ backgroundColor: 'green', color: 'white' }}>Accept</Button>
       </Link>
       <Button variant="danger" onClick={decline} disabled={loading}>Reject</Button>
-      <Link href={`/candidate/detail/${candidateId}`}>
+      <Link href={`/professional/detail/${candidateId}`}>
         <Button variant="primary">View Details</Button>
       </Link>
     </div>

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,11 +1,12 @@
-export interface ProfessionalResponse {
+export interface ProfileResponse {
   identity: { name?: string; email?: string; redacted?: boolean };
-  title: string;
-  priceUSD: number;
-  tags: string[];
+  title?: string;
+  priceUSD?: number;
+  tags?: string[];
   verified?: boolean;
   bio?: string;
   employer?: string;
+  resumeUrl?: string;
   experience?: {
     firm: string;
     title: string;


### PR DESCRIPTION
## Summary
- Replace "view" link to point professionals to `/professional/detail/[candidateId]`
- Introduce `ProfileDetail` component and `ProfileResponse` type for displaying both professional and candidate profiles
- Add professional-facing candidate detail page and API endpoint
- Build candidate detail API requests from request headers for flexibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba2fbbc0ac8325b25395f00c3ba4ae