### PR TITLE
feat: add password reset flow

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,7 @@ model User {
   notifications          Notification[]
   auditLogs              AuditLog[]           @relation("AuditActor")
   availabilities         Availability[]
+  passwordResetTokens   PasswordResetToken[]
 
   @@index([role])
 }
@@ -87,6 +88,16 @@ model OAuthAccount {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
+}
+
+model PasswordResetToken {
+  id        String   @id @default(cuid())
+  userId    String
+  token     String   @unique
+  expiresAt DateTime
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([expiresAt])
 }
 
 model ProfessionalProfile {

--- a/src/app/(public)/forgot-password/ForgotPasswordForm.tsx
+++ b/src/app/(public)/forgot-password/ForgotPasswordForm.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { useState } from 'react';
+import { Input, Button } from '../../../components/ui';
+
+export default function ForgotPasswordForm() {
+  const [sent, setSent] = useState(false);
+  const [email, setEmail] = useState('');
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    await fetch('/api/auth/forgot-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    setSent(true);
+  }
+  if (sent) {
+    return <p>Check your email for a reset link.</p>;
+  }
+  return (
+    <form onSubmit={handleSubmit} className="col" style={{ gap: 12 }}>
+      <Input
+        type="email"
+        name="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        required
+      />
+      <Button type="submit">Send reset link</Button>
+    </form>
+  );
+}

--- a/src/app/(public)/forgot-password/page.tsx
+++ b/src/app/(public)/forgot-password/page.tsx
@@ -1,0 +1,11 @@
+import { Card } from '../../../components/ui';
+import ForgotPasswordForm from './ForgotPasswordForm';
+
+export default function ForgotPasswordPage() {
+  return (
+    <Card style={{ maxWidth: 400, margin: '40px auto', padding: 24 }}>
+      <h1>Forgot Password</h1>
+      <ForgotPasswordForm />
+    </Card>
+  );
+}

--- a/src/app/(public)/login/LoginForm.tsx
+++ b/src/app/(public)/login/LoginForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useState } from 'react';
 import { signIn, type SignInResponse } from 'next-auth/react';
+import Link from 'next/link';
 import { z } from 'zod';
 import { Input, Button } from '../../../components/ui';
 
@@ -65,6 +66,9 @@ export default function LoginForm() {
         required
       />
       <Input name="password" type="password" placeholder="Password" required />
+      <div style={{ alignSelf: 'flex-end' }}>
+        <Link href="/forgot-password">Forgot password?</Link>
+      </div>
       {error && <p style={{ color: 'red' }}>{error}</p>}
       <Button type="submit">Log In</Button>
       <Button

--- a/src/app/(public)/reset-password/ResetPasswordForm.tsx
+++ b/src/app/(public)/reset-password/ResetPasswordForm.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Input, Button } from '../../../components/ui';
+
+export default function ResetPasswordForm() {
+  const params = useSearchParams();
+  const token = params.get('token') || '';
+  const [password, setPassword] = useState('');
+  const [done, setDone] = useState(false);
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    await fetch('/api/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, password }),
+    });
+    setDone(true);
+  }
+  if (!token) {
+    return <p>Invalid reset link.</p>;
+  }
+  if (done) {
+    return <p>Password updated. You can now log in.</p>;
+  }
+  return (
+    <form onSubmit={handleSubmit} className="col" style={{ gap: 12 }}>
+      <Input
+        type="password"
+        name="password"
+        placeholder="New password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <Button type="submit">Reset Password</Button>
+    </form>
+  );
+}

--- a/src/app/(public)/reset-password/page.tsx
+++ b/src/app/(public)/reset-password/page.tsx
@@ -1,0 +1,11 @@
+import { Card } from '../../../components/ui';
+import ResetPasswordForm from './ResetPasswordForm';
+
+export default function ResetPasswordPage() {
+  return (
+    <Card style={{ maxWidth: 400, margin: '40px auto', padding: 24 }}>
+      <h1>Reset Password</h1>
+      <ResetPasswordForm />
+    </Card>
+  );
+}

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '../../../../lib/db';
+import { mailer } from '../../../../lib/email';
+import { v4 as uuid } from 'uuid';
+import { z } from 'zod';
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  const schema = z.object({ email: z.string().email() });
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ ok: true });
+  }
+  const { email } = parsed.data;
+  const user = await prisma.user.findUnique({ where: { email } });
+  if (!user) {
+    return NextResponse.json({ ok: true });
+  }
+  const token = uuid();
+  await prisma.passwordResetToken.create({
+    data: {
+      userId: user.id,
+      token,
+      expiresAt: new Date(Date.now() + 1000 * 60 * 60),
+    },
+  });
+  const baseUrl =
+    process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXTAUTH_URL ||
+    'http://localhost:3000';
+  const resetUrl = `${baseUrl}/reset-password?token=${token}`;
+  try {
+    await mailer.sendMail({
+      to: email,
+      subject: 'Reset your password',
+      text: `Click the following link to reset your password: ${resetUrl}`,
+    });
+  } catch {
+    // ignore mail errors
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/auth/reset-password/route.ts
+++ b/src/app/api/auth/reset-password/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '../../../../lib/db';
+import { z } from 'zod';
+import bcrypt from 'bcryptjs';
+
+export async function POST(req: Request) {
+  const body = await req.json().catch(() => null);
+  const schema = z.object({ token: z.string(), password: z.string().min(6) });
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'invalid' }, { status: 400 });
+  }
+  const { token, password } = parsed.data;
+  const record = await prisma.passwordResetToken.findUnique({ where: { token } });
+  if (!record || record.expiresAt < new Date()) {
+    return NextResponse.json({ error: 'invalid' }, { status: 400 });
+  }
+  const hashed = await bcrypt.hash(password, 10);
+  await prisma.user.update({ where: { id: record.userId }, data: { hashedPassword: hashed } });
+  await prisma.passwordResetToken.delete({ where: { token } });
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
## Summary
- add PasswordResetToken model to persist reset tokens
- add APIs and pages to request and perform password resets
- link to password reset from login form

## Testing
- `npx prisma generate`
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68bae73d441c83258d2015949ed48b12