### PR TITLE
Allow editing Stripe Connect from settings

### DIFF
--- a/lib/payments/stripe.ts
+++ b/lib/payments/stripe.ts
@@ -106,6 +106,21 @@ export async function createAccountOnboardingLink(
   return link.url;
 }
 
+/** Create an Express account update link for a connected account */
+export async function createAccountUpdateLink(
+  accountId: string,
+  refreshUrl: string,
+  returnUrl: string,
+) {
+  const link = await stripe.accountLinks.create({
+    account: accountId,
+    refresh_url: refreshUrl,
+    return_url: returnUrl,
+    type: 'account_update',
+  });
+  return link.url;
+}
+
 /**
  * Release held funds to a professional's connected Stripe account.
  * The platform retains the fee recorded at checkout.

--- a/src/app/api/stripe/account/route.ts
+++ b/src/app/api/stripe/account/route.ts
@@ -5,6 +5,7 @@ import {
   stripe,
   ensureConnectedAccount,
   createAccountOnboardingLink,
+  createAccountUpdateLink,
 } from '../../../../../lib/payments/stripe';
 
 export async function GET(_req: NextRequest) {
@@ -54,13 +55,20 @@ export async function POST(_req: NextRequest) {
       user.firstName || '',
       user.lastName || '',
     );
+    const account = await stripe.accounts.retrieve(accountId);
     const baseUrl = process.env.APP_URL || 'http://localhost:3000';
-    const onboardingUrl = await createAccountOnboardingLink(
-      accountId,
-      `${baseUrl}/professional/settings`,
-      `${baseUrl}/professional/settings`,
-    );
-    return NextResponse.json({ onboardingUrl });
+    const url = account.details_submitted
+      ? await createAccountUpdateLink(
+          accountId,
+          `${baseUrl}/professional/settings`,
+          `${baseUrl}/professional/settings`,
+        )
+      : await createAccountOnboardingLink(
+          accountId,
+          `${baseUrl}/professional/settings`,
+          `${baseUrl}/professional/settings`,
+        );
+    return NextResponse.json({ onboardingUrl: url });
   } catch (e) {
     return NextResponse.json({ error: 'stripe_error' }, { status: 500 });
   }

--- a/src/app/professional/settings/StripeSection.tsx
+++ b/src/app/professional/settings/StripeSection.tsx
@@ -33,7 +33,7 @@ export default function StripeSection() {
       setMessage('Redirecting to Stripe...');
       window.location.href = data.onboardingUrl;
     } catch {
-      setError('Failed to start Stripe onboarding');
+      setError('Failed to open Stripe');
     } finally {
       setLoading(false);
     }
@@ -50,22 +50,19 @@ export default function StripeSection() {
       ? 'Loading...'
       : 'Not connected';
 
-  const canConnect =
-    status === 'not_connected' || status === 'incomplete';
-
   return (
     <>
       <h3>Payment</h3>
       <p>Onboard to Stripe Connect to receive payouts.</p>
-      {canConnect && (
-        <Button onClick={handleConnect} disabled={loading}>
-          {loading
-            ? 'Loading...'
-            : status === 'incomplete'
-            ? 'Resume Onboarding'
-            : 'Connect Stripe'}
-        </Button>
-      )}
+      <Button onClick={handleConnect} disabled={loading || status === 'loading'}>
+        {loading || status === 'loading'
+          ? 'Loading...'
+          : status === 'incomplete'
+          ? 'Resume Onboarding'
+          : status === 'not_connected'
+          ? 'Connect Stripe'
+          : 'Edit Stripe'}
+      </Button>
       <p>Account status: {statusLabel}</p>
       {error && <p style={{ color: 'red' }}>{error}</p>}
       {message && <p style={{ color: 'green' }}>{message}</p>}


### PR DESCRIPTION
## Summary
- Always show Stripe Connect management button in professional settings
- Provide update link for connected accounts, enabling edits regardless of status
- Add helper to create Stripe account update links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc9d470b348325999cbd74ed901225