### PR TITLE
Disable OAuth signup until role selected

### DIFF
--- a/src/app/(public)/signup/SignUpForm.tsx
+++ b/src/app/(public)/signup/SignUpForm.tsx
@@ -77,14 +77,16 @@ export default function SignUpForm() {
       <Button
         type="button"
         onClick={() => handleOAuth('google')}
-        variant="muted"
+        variant={role ? 'primary' : 'muted'}
+        disabled={!role}
       >
         Sign up with Google
       </Button>
       <Button
         type="button"
         onClick={() => handleOAuth('linkedin')}
-        variant="muted"
+        variant={role ? 'primary' : 'muted'}
+        disabled={!role}
       >
         Sign up with LinkedIn
       </Button>


### PR DESCRIPTION
## Summary
- disable Google/LinkedIn signup buttons until the user chooses a role
- show grey variant for OAuth buttons before role selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc9dce57dc83258b63390feaf744ba