### PR TITLE
Fix feedback fetch URL for history pages

### DIFF
--- a/src/app/candidate/history/[bookingId]/page.tsx
+++ b/src/app/candidate/history/[bookingId]/page.tsx
@@ -10,7 +10,8 @@ export default async function FeedbackPage({ params }: { params: { bookingId: st
     redirect("/login");
   }
 
-  const res = await fetch(`/api/feedback/${params.bookingId}`, {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const res = await fetch(`${baseUrl}/api/feedback/${params.bookingId}`, {
     cache: "no-store",
     headers: {
       cookie: cookies().toString(),

--- a/src/app/professional/history/[bookingId]/page.tsx
+++ b/src/app/professional/history/[bookingId]/page.tsx
@@ -14,7 +14,8 @@ export default async function ProfessionalHistoryPage({
     redirect("/login");
   }
 
-  const res = await fetch(`/api/feedback/${params.bookingId}`, {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
+  const res = await fetch(`${baseUrl}/api/feedback/${params.bookingId}`, {
     cache: "no-store",
     headers: {
       cookie: cookies().toString(),


### PR DESCRIPTION
## Summary
- fetch feedback via absolute URL on candidate and professional history pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf1d83dc083258daa29785110791c