### PR TITLE
Check for feedback existence on candidate calls page

### DIFF
--- a/src/app/candidate/calls/page.tsx
+++ b/src/app/candidate/calls/page.tsx
@@ -98,6 +98,7 @@ export default async function CallsPage({
             professionalProfile: { select: { title: true, employer: true } },
           },
         },
+        feedback: { select: { bookingId: true } },
       },
       orderBy: { startAt: "desc" },
       skip: (page - 1) * perPage,
@@ -116,7 +117,7 @@ export default async function CallsPage({
       (Date.now() - new Date(b.createdAt).getTime()) / (1000 * 60 * 60 * 24)
     );
     const callDate = new Date(b.startAt);
-    const hasHappened = callDate.getTime() <= Date.now();
+    const hasFeedback = Boolean(b.feedback);
     return {
       name,
       firm: b.professional.professionalProfile?.employer ?? "",
@@ -128,7 +129,7 @@ export default async function CallsPage({
           {toPascalCase(b.status)}
         </span>
       ),
-      feedback: hasHappened
+      feedback: hasFeedback
         ? { label: "View Feedback", href: `/candidate/history/${b.id}` }
         : { label: "View Feedback", variant: "muted", disabled: true },
     };


### PR DESCRIPTION
## Summary
- Include feedback relation when fetching bookings for candidate calls
- Only enable View Feedback link when a Feedback record exists

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be4b96ab0c8325b921b552a44579e2