### PR TITLE
refactor: isolate edge auth config

### DIFF
--- a/src/auth-edge.ts
+++ b/src/auth-edge.ts
@@ -1,0 +1,21 @@
+import NextAuth from 'next-auth';
+
+// Minimal NextAuth configuration for Edge runtime
+export const { auth } = NextAuth({
+  session: { strategy: 'jwt' },
+  secret: process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET || 'dev-secret',
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.role = (user as any).role || 'CANDIDATE';
+        token.uid = (user as any).id;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      (session.user as any).id = token.uid as string;
+      (session.user as any).role = (token.role as any) || 'CANDIDATE';
+      return session;
+    },
+  },
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,5 @@
-export { auth as middleware } from './auth';
+// Use a lightweight auth config that is compatible with the Edge runtime.
+export { auth as middleware } from './auth-edge';
 
 // Apply auth middleware to all routes except Next.js internals and static assets.
 // API routes are excluded here but must call `auth()` themselves for protection.


### PR DESCRIPTION
## Summary
- use edge-safe NextAuth config in middleware to avoid loading Prisma in edge runtime

## Testing
- `npm test`
- `CI=1 npm run build` *(fails: Module not found: Can't resolve '../../../../lib/db')*

------
https://chatgpt.com/codex/tasks/task_e_68c225ff45ec83258219b41aec16c41b