### PR TITLE
fix Prisma client global assignment type error

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -15,12 +15,13 @@ function toZoned(date: Date) {
   return Temporal.Instant.from(date.toISOString()).toZonedDateTimeISO(tz);
 }
 
-export const prisma = (
-  globalForPrisma.prisma ||
+const client =
+  globalForPrisma.prisma ??
   new PrismaClient({
     datasourceUrl: process.env.DATABASE_URL,
-  })
-).$extends({
+  });
+
+export const prisma = client.$extends({
   result: {
     $allModels: {
       $allFields: {
@@ -33,5 +34,5 @@ export const prisma = (
 });
 
 if (process.env.NODE_ENV !== 'production') {
-  globalForPrisma.prisma = prisma;
+  globalForPrisma.prisma = client;
 }


### PR DESCRIPTION
## Summary
- refactor Prisma client initialization to cache the base client and export an extended version

## Testing
- `npm test`
- `npm run build` *(fails: process terminated after compiling and linting due to environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68c23669dc188325b0054ee00f4bb817