### PR TITLE
Handle email send failures without aborting flow

### DIFF
--- a/lib/email.ts
+++ b/lib/email.ts
@@ -10,8 +10,8 @@ const mailer = nodemailer.createTransport({
 });
 
 /**
- * Sends an email using the configured SMTP transport. Errors are logged and
- * rethrown so callers can surface failures to users.
+ * Sends an email using the configured SMTP transport. Errors are logged but
+ * execution continues so that failures to send mail don't halt the caller.
  */
 export async function sendEmail(options: Mail.Options) {
   if (!process.env.SMTP_HOST) return;
@@ -19,6 +19,6 @@ export async function sendEmail(options: Mail.Options) {
     await mailer.sendMail(options);
   } catch (err) {
     console.error('Failed to send email', err);
-    throw err;
+    // Swallow the error to avoid interrupting caller execution
   }
 }

--- a/src/app/api/auth/forgot-password/route.ts
+++ b/src/app/api/auth/forgot-password/route.ts
@@ -29,16 +29,10 @@ export async function POST(req: Request) {
     process.env.NEXTAUTH_URL ||
     'http://localhost:3000';
   const resetUrl = `${baseUrl}/reset-password?token=${token}`;
-  try {
-    await sendEmail({
-      to: email,
-      subject: 'Reset your password',
-      text: `Click the following link to reset your password: ${resetUrl}`,
-    });
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : 'Failed to send email';
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+  await sendEmail({
+    to: email,
+    subject: 'Reset your password',
+    text: `Click the following link to reset your password: ${resetUrl}`,
+  });
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/bookings/[id]/schedule/route.ts
+++ b/src/app/api/bookings/[id]/schedule/route.ts
@@ -37,18 +37,12 @@ export async function POST(req: NextRequest, { params }:{params:{id:string}}){
   )}\nDTSTART:${formatICS(start)}\nDTEND:${formatICS(end)}\nSUMMARY:Mentorship Call\nDESCRIPTION:Join Zoom meeting at ${zoom.join_url}\nURL:${zoom.join_url}\nEND:VEVENT\nEND:VCALENDAR`;
   const recipients = [proEmail, candEmail].filter(Boolean).join(',');
   if (recipients) {
-    try {
-      await sendEmail({
-        to: recipients,
-        subject: 'Call Confirmed',
-        text: `Join Zoom meeting: ${zoom.join_url}`,
-        icalEvent: { method: 'REQUEST', filename: 'invite.ics', content: ics },
-      });
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : 'Failed to send email';
-      return NextResponse.json({ error: message }, { status: 500 });
-    }
+    await sendEmail({
+      to: recipients,
+      subject: 'Call Confirmed',
+      text: `Join Zoom meeting: ${zoom.join_url}`,
+      icalEvent: { method: 'REQUEST', filename: 'invite.ics', content: ics },
+    });
   }
 
   return NextResponse.json({ id: updated.id, startAt: updated.startAt, endAt: updated.endAt, status: updated.status });

--- a/src/app/api/bookings/request/route.ts
+++ b/src/app/api/bookings/request/route.ts
@@ -29,17 +29,11 @@ export async function POST(req: NextRequest){
     select: { email: true },
   });
   if (proUser?.email) {
-    try {
-      await sendEmail({
-        to: proUser.email,
-        subject: 'New booking request',
-        text: `You have a new booking request from ${session.user.email}.`,
-      });
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : 'Failed to send email';
-      return NextResponse.json({ error: message }, { status: 500 });
-    }
+    await sendEmail({
+      to: proUser.email,
+      subject: 'New booking request',
+      text: `You have a new booking request from ${session.user.email}.`,
+    });
   }
   return NextResponse.json({ id: booking.id, status: booking.status, priceUSD: booking.priceUSD });
 }

--- a/src/app/api/verification/request/route.ts
+++ b/src/app/api/verification/request/route.ts
@@ -11,16 +11,10 @@ export async function POST(req: NextRequest){
   await prisma.verification.create({
     data: { userId: session.user.id, corporateEmail, token },
   });
-  try {
-    await sendEmail({
-      to: corporateEmail,
-      subject: 'Verify your corporate email',
-      text: `Click: ${process.env.APP_URL}/api/verification/confirm?token=${token}`,
-    });
-  } catch (err) {
-    const message =
-      err instanceof Error ? err.message : 'Failed to send email';
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+  await sendEmail({
+    to: corporateEmail,
+    subject: 'Verify your corporate email',
+    text: `Click: ${process.env.APP_URL}/api/verification/confirm?token=${token}`,
+  });
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
## Summary
- log and swallow errors when sending email
- continue API routes after failed email sends

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7f7db4e788325aa57afd36e997235