### PR TITLE
Anonymize candidate names in professional feedback

### DIFF
--- a/src/app/api/professionals/[id]/route.ts
+++ b/src/app/api/professionals/[id]/route.ts
@@ -50,13 +50,11 @@ export async function GET(
 
   const reviews = await prisma.professionalReview.findMany({
     where: { booking: { professionalId: params.id } },
-    include: { booking: { include: { candidate: true } } },
     orderBy: { submittedAt: 'desc' },
   });
   payload.reviews = reviews.map((r) => ({
     rating: r.rating,
     text: r.text,
-    candidate: r.booking.candidate.email,
     submittedAt: r.submittedAt,
   }));
 

--- a/src/components/ProfileDetail.tsx
+++ b/src/components/ProfileDetail.tsx
@@ -146,7 +146,7 @@ export default function ProfileDetail({
             profile.reviews.map((r, idx) => (
               <div key={idx} className="col" style={{ gap: 4 }}>
                 <div className="row" style={{ justifyContent: 'space-between', alignItems: 'center' }}>
-                  <strong>{r.candidate}</strong>
+                  <strong>{`Candidate ${idx + 1}`}</strong>
                   <span>{'★'.repeat(r.rating)}{'☆'.repeat(5 - r.rating)}</span>
                 </div>
                 <p>{r.text}</p>

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -24,7 +24,6 @@ export interface ProfileResponse {
   reviews?: {
     rating: number;
     text: string;
-    candidate: string;
     submittedAt: string;
   }[];
 }


### PR DESCRIPTION
## Summary
- Remove candidate identifiers from professional reviews API
- Display reviews with generic "Candidate <n>" labels on profile pages
- Update profile types to exclude candidate names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7fa9befb883259d7a20f537550424