### PR TITLE
Blank call date for requested candidate calls

### DIFF
--- a/src/app/candidate/calls/page.tsx
+++ b/src/app/candidate/calls/page.tsx
@@ -116,14 +116,15 @@ export default async function CallsPage({
     const daysSince = Math.floor(
       (Date.now() - new Date(b.createdAt).getTime()) / (1000 * 60 * 60 * 24)
     );
-    const callDate = new Date(b.startAt);
+    const callDateLabel =
+      b.status === BookingStatus.requested ? "" : formatDateTime(b.startAt);
     const hasFeedback = Boolean(b.feedback);
     return {
       name,
       firm: b.professional.professionalProfile?.employer ?? "",
       title: b.professional.professionalProfile?.title ?? "",
       days: String(daysSince),
-      date: { label: formatDateTime(callDate) },
+      date: { label: callDateLabel },
       status: (
         <span className="badge" style={statusStyle(b.status)}>
           {cleanStatus(b.status)}


### PR DESCRIPTION
## Summary
- hide the date label on candidate calls that are still in the requested state so unconfirmed calls show a blank date

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c8c451b8d883259219acb1e43c35bc