### PR TITLE
Ensure availability calendar persists selections with onConfirm

### DIFF
--- a/src/components/AvailabilityCalendar.tsx
+++ b/src/components/AvailabilityCalendar.tsx
@@ -50,14 +50,13 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({
     if (isEdit) {
       const end = addDays(new Date(), weeks * 7);
       const filtered = events.filter(e => new Date(e.start) < end);
+      await fetch('/api/candidate/availability', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ events: filtered, busy: [...busyEvents, ...defaultBusy] }),
+      });
       if (onConfirm) {
         await onConfirm(filtered);
-      } else {
-        await fetch('/api/candidate/availability', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ events: filtered, busy: [...busyEvents, ...defaultBusy] }),
-        });
       }
     } else if (onConfirm && selected) {
       await onConfirm([selected]);


### PR DESCRIPTION
## Summary
- ensure the availability calendar always posts the candidate's availability updates even when an onConfirm callback is supplied
- maintain downstream confirm behaviour by calling the provided onConfirm after persisting availability

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68cc049a06c88325a98982131940d8dc