### PR TITLE
Prefetch checkout data for immediate Stripe render

### DIFF
--- a/src/app/candidate/detail/[id]/schedule/checkout/CheckoutClient.tsx
+++ b/src/app/candidate/detail/[id]/schedule/checkout/CheckoutClient.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { loadStripe } from "@stripe/stripe-js";
+import {
+  Elements,
+  PaymentElement,
+  useElements,
+  useStripe,
+} from "@stripe/react-stripe-js";
+
+import { Card, Button } from "../../../../../../components/ui";
+import type { ProfileResponse } from "../../../../../../types/profile";
+import type { TimeSlot } from "../../../../../../../lib/availability";
+import { convertTimeSlotsTimezone } from "../../../../../../../lib/availability";
+
+const stripePromise = loadStripe(
+  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || ""
+);
+
+type CheckoutFormProps = {
+  professionalId: string;
+  slots: TimeSlot[];
+  weeks: number;
+  candidateTimezone: string;
+};
+
+function CheckoutForm({
+  professionalId,
+  slots,
+  weeks,
+  candidateTimezone,
+}: CheckoutFormProps) {
+  const stripe = useStripe();
+  const elements = useElements();
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isPaymentElementReady, setIsPaymentElementReady] = useState(false);
+
+  const normalizedSlots = useMemo(
+    () => convertTimeSlotsTimezone(slots, candidateTimezone),
+    [slots, candidateTimezone]
+  );
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!stripe || !elements) return;
+
+    const paymentElement = elements.getElement(PaymentElement);
+    if (!paymentElement) {
+      window.alert("Payment form is not ready. Please try again in a moment.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const { error, paymentIntent } = await stripe.confirmPayment({
+        elements,
+        redirect: "if_required",
+      });
+
+      if (error) {
+        window.alert(error.message || "Payment failed");
+        return;
+      }
+
+      if (paymentIntent?.status === "succeeded") {
+        const res = await fetch("/api/bookings/request", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ professionalId, slots: normalizedSlots, weeks }),
+        });
+
+        if (res.ok) {
+          window.alert("Your booking request has been sent.");
+          router.push("/candidate/dashboard");
+        }
+      }
+    } catch (err) {
+      window.alert("An unexpected error occurred while processing the payment.");
+      console.error(err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="col" style={{ gap: 16 }}>
+      <PaymentElement onReady={() => setIsPaymentElementReady(true)} />
+      <Button type="submit" disabled={!stripe || !isPaymentElementReady || isSubmitting}>
+        {isSubmitting ? "Processing..." : "Pay"}
+      </Button>
+    </form>
+  );
+}
+
+type CheckoutClientProps = {
+  professionalId: string;
+  clientSecret: string | null;
+  professional: ProfileResponse | null;
+  slots: TimeSlot[];
+  weeks: number;
+  candidateTimezone: string;
+  errorMessage?: string | null;
+};
+
+export default function CheckoutClient({
+  professionalId,
+  clientSecret,
+  professional,
+  slots,
+  weeks,
+  candidateTimezone,
+  errorMessage,
+}: CheckoutClientProps) {
+  const summaryCard = professional ? (
+    <Card className="col" style={{ padding: 16, gap: 8 }}>
+      <p>
+        You are booking a 30 minute chat with {professional.title} at {professional.employer}.
+      </p>
+      <p>The professional will only be paid once they provide feedback.</p>
+    </Card>
+  ) : null;
+
+  if (!clientSecret) {
+    return (
+      <div className="col" style={{ gap: 16 }}>
+        {summaryCard}
+        <Card className="col" style={{ padding: 16, gap: 8 }}>
+          <p>{errorMessage ?? "We were unable to load the payment form. Please refresh and try again."}</p>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <Elements stripe={stripePromise} options={{ clientSecret }}>
+      <div className="col" style={{ gap: 16 }}>
+        {summaryCard}
+        <CheckoutForm
+          professionalId={professionalId}
+          slots={slots}
+          weeks={weeks}
+          candidateTimezone={candidateTimezone}
+        />
+      </div>
+    </Elements>
+  );
+}

--- a/src/app/candidate/detail/[id]/schedule/checkout/page.tsx
+++ b/src/app/candidate/detail/[id]/schedule/checkout/page.tsx
@@ -1,155 +1,125 @@
-"use client";
+import { cookies } from "next/headers";
 
-import { useEffect, useMemo, useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { loadStripe } from "@stripe/stripe-js";
-import {
-  Elements,
-  PaymentElement,
-  useElements,
-  useStripe,
-} from "@stripe/react-stripe-js";
-import { Card, Button } from "../../../../../../components/ui";
-import { ProfileResponse } from "../../../../../../types/profile";
+import CheckoutClient from "./CheckoutClient";
 import {
   TimeSlot,
-  normalizeSlots,
-  convertTimeSlotsTimezone,
   getDefaultTimezone,
+  normalizeSlots,
 } from "../../../../../../../lib/availability";
+import type { ProfileResponse } from "../../../../../../types/profile";
 
-const stripePromise = loadStripe(
-  process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || ""
-);
+const PAYMENT_ERROR_MESSAGE =
+  "We were unable to load the payment form. Please refresh and try again.";
 
-function CheckoutForm({
-  professionalId,
-  slots,
-  weeks,
-  candidateTimezone,
-}: {
-  professionalId: string;
-  slots: TimeSlot[];
-  weeks: number;
-  candidateTimezone: string;
-}) {
-  const stripe = useStripe();
-  const elements = useElements();
-  const router = useRouter();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [isPaymentElementReady, setIsPaymentElementReady] = useState(false);
+type PageProps = {
+  params: { id: string };
+  searchParams: Record<string, string | string[] | undefined>;
+};
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!stripe || !elements) return;
-
-    const paymentElement = elements.getElement(PaymentElement);
-    if (!paymentElement) {
-      window.alert("Payment form is not ready. Please try again in a moment.");
-      return;
-    }
-
-    setIsSubmitting(true);
-
-    try {
-      const { error, paymentIntent } = await stripe.confirmPayment({
-        elements,
-        redirect: "if_required",
-      });
-
-      if (error) {
-        window.alert(error.message || "Payment failed");
-        return;
-      }
-      if (paymentIntent?.status === "succeeded") {
-        const normalizedSlots = convertTimeSlotsTimezone(slots, candidateTimezone);
-        const res = await fetch("/api/bookings/request", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ professionalId, slots: normalizedSlots, weeks }),
-        });
-        if (res.ok) {
-          window.alert("Your booking request has been sent.");
-          router.push("/candidate/dashboard");
-        }
-      }
-    } catch (err) {
-      window.alert("An unexpected error occurred while processing the payment.");
-      console.error(err);
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="col" style={{ gap: 16 }}>
-      <PaymentElement onReady={() => setIsPaymentElementReady(true)} />
-      <Button type="submit" disabled={!stripe || !isPaymentElementReady || isSubmitting}>
-        {isSubmitting ? "Processing..." : "Pay"}
-      </Button>
-    </form>
-  );
+function firstValue(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+  return value ?? null;
 }
 
-export default function CheckoutPage({ params }: { params: { id: string } }) {
-  const searchParams = useSearchParams();
-  const fallbackTimezone = useMemo(() => getDefaultTimezone(), []);
-
-  const slotsParam = searchParams.get("slots");
-  const slots: TimeSlot[] = useMemo(() => {
-    if (!slotsParam) return [];
-    try {
-      const parsed = JSON.parse(slotsParam);
-      if (!Array.isArray(parsed)) return [];
-      return normalizeSlots(parsed, fallbackTimezone);
-    } catch {
-      return [];
-    }
-  }, [slotsParam, fallbackTimezone]);
-  const weeks = parseInt(searchParams.get("weeks") || "2");
-  const [clientSecret, setClientSecret] = useState<string | null>(null);
-  const [pro, setPro] = useState<ProfileResponse | null>(null);
-
-  useEffect(() => {
-    fetch(`/api/professionals/${params.id}`).then(async (res) => {
-      if (res.ok) {
-        const data: ProfileResponse = await res.json();
-        setPro(data);
-      }
-    });
-  }, [params.id]);
-
-  useEffect(() => {
-    fetch("/api/stripe/intent", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ professionalId: params.id }),
-    })
-      .then((res) => res.json())
-      .then((data) => setClientSecret(data.clientSecret));
-  }, [params.id]);
-
-  if (!clientSecret) return <p>Loading...</p>;
-
-  return (
-    <Elements stripe={stripePromise} options={{ clientSecret }}>
-      <div className="col" style={{ gap: 16 }}>
-        {pro && (
-          <Card className="col" style={{ padding: 16, gap: 8 }}>
-            <p>
-              You are booking a 30 minute chat with {pro.title} at {pro.employer}.
-            </p>
-            <p>The professional will only be paid once they provide feedback.</p>
-          </Card>
-        )}
-        <CheckoutForm
-          professionalId={params.id}
-          slots={slots}
-          weeks={weeks}
-          candidateTimezone={fallbackTimezone}
-        />
-      </div>
-    </Elements>
-  );
+function parseSlots(
+  slotsParam: string | null,
+  fallbackTimezone: string
+): TimeSlot[] {
+  if (!slotsParam) return [];
+  try {
+    const parsed = JSON.parse(slotsParam);
+    if (!Array.isArray(parsed)) return [];
+    return normalizeSlots(parsed, fallbackTimezone);
+  } catch {
+    return [];
+  }
 }
 
+function parseWeeks(weeksParam: string | null): number {
+  const parsed = Number.parseInt(weeksParam ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 2;
+}
+
+type CheckoutData = {
+  professional: ProfileResponse | null;
+  clientSecret: string | null;
+  errorMessage: string | null;
+};
+
+async function loadCheckoutData(professionalId: string): Promise<CheckoutData> {
+  const cookieHeader = cookies().toString();
+  const sharedHeaders = cookieHeader ? { cookie: cookieHeader } : undefined;
+
+  try {
+    const [professionalRes, intentRes] = await Promise.all([
+      fetch(`/api/professionals/${professionalId}`, {
+        cache: "no-store",
+        headers: {
+          ...(sharedHeaders ?? {}),
+        },
+      }),
+      fetch(`/api/stripe/intent`, {
+        method: "POST",
+        cache: "no-store",
+        headers: {
+          "Content-Type": "application/json",
+          ...(sharedHeaders ?? {}),
+        },
+        body: JSON.stringify({ professionalId }),
+      }),
+    ]);
+
+    let professional: ProfileResponse | null = null;
+    if (professionalRes.ok) {
+      professional = (await professionalRes.json()) as ProfileResponse;
+    }
+
+    if (intentRes.ok) {
+      const intentData = await intentRes.json();
+      const secret = intentData?.clientSecret;
+      if (typeof secret === "string") {
+        return { professional, clientSecret: secret, errorMessage: null };
+      }
+    }
+
+    return {
+      professional,
+      clientSecret: null,
+      errorMessage: PAYMENT_ERROR_MESSAGE,
+    };
+  } catch (error) {
+    console.error("Failed to load checkout data", error);
+    return {
+      professional: null,
+      clientSecret: null,
+      errorMessage: PAYMENT_ERROR_MESSAGE,
+    };
+  }
+}
+
+export default async function CheckoutPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const fallbackTimezone = getDefaultTimezone();
+  const slots = parseSlots(firstValue(searchParams.slots), fallbackTimezone);
+  const weeks = parseWeeks(firstValue(searchParams.weeks));
+
+  const { professional, clientSecret, errorMessage } = await loadCheckoutData(
+    params.id
+  );
+
+  return (
+    <CheckoutClient
+      professionalId={params.id}
+      professional={professional}
+      clientSecret={clientSecret}
+      slots={slots}
+      weeks={weeks}
+      candidateTimezone={fallbackTimezone}
+      errorMessage={errorMessage}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- fetch the professional profile and Stripe payment intent on the server so the checkout view renders with a ready client secret
- move the Stripe Elements form into a dedicated client component that handles submission, timezone conversion, and fallback messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d13a4e2c848325972db2a5c844009b