### PR TITLE
Fix availability type re-exports

### DIFF
--- a/lib/availability.ts
+++ b/lib/availability.ts
@@ -1,8 +1,7 @@
 import { startOfWeek } from 'date-fns';
 import { formatInTimeZone, fromZonedTime, toZonedTime } from 'date-fns-tz';
+import type { DateTime, TimeSlot } from './time-slot';
 import {
-  DateTime,
-  TimeSlot,
   createTimeSlotFromDates as createTimeSlotFromDatesInternal,
   ensureTimezone as ensureTimezoneInternal,
   toUtcDateRange as toUtcDateRangeInternal,
@@ -133,4 +132,5 @@ export function splitIntoSlots(ranges: Slot[], minutes = 30): Slot[] {
   return result;
 }
 
-export { DateTime, TimeSlot, ISO_LOCAL_FORMAT };
+export type { DateTime, TimeSlot };
+export { ISO_LOCAL_FORMAT };

--- a/lib/calendar/google.ts
+++ b/lib/calendar/google.ts
@@ -1,6 +1,7 @@
 import { google } from 'googleapis';
 import { prisma } from '../db';
-import { TimeSlot, createTimeSlotFromDates, ensureTimezone } from '../availability';
+import type { TimeSlot } from '../availability';
+import { createTimeSlotFromDates, ensureTimezone } from '../availability';
 
 const GOOGLE_FREE_BUSY_TIMEZONE = 'America/New_York';
 

--- a/src/app/api/bookings/request/route.ts
+++ b/src/app/api/bookings/request/route.ts
@@ -3,7 +3,8 @@ import { prisma } from '../../../../../lib/db';
 import { rateLimit } from '../../../../../lib/rate-limit';
 import { auth } from '@/auth';
 import { sendEmail } from '../../../../../lib/email';
-import { TimeSlot, toUtcDateRange, resolveTimezone, normalizeSlots } from '../../../../../lib/availability';
+import type { TimeSlot } from '../../../../../lib/availability';
+import { toUtcDateRange, resolveTimezone, normalizeSlots } from '../../../../../lib/availability';
 
 export async function POST(req: NextRequest) {
   const session = await auth();

--- a/src/app/api/candidate/availability/route.ts
+++ b/src/app/api/candidate/availability/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { prisma } from '../../../../../lib/db';
+import type { TimeSlot } from '../../../../../lib/availability';
 import {
-  TimeSlot,
   mergeSlots,
   splitIntoSlots,
   createTimeSlotFromDates,

--- a/src/app/candidate/detail/[id]/schedule/page.tsx
+++ b/src/app/candidate/detail/[id]/schedule/page.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import AvailabilityCalendar from "../../../../../components/AvailabilityCalendar";
 import { Card, Input } from "../../../../../components/ui";
-import { TimeSlot } from "../../../../../lib/availability";
+import type { TimeSlot } from "../../../../../lib/availability";
 
 export default function Schedule({ params }: { params: { id: string } }) {
   const [weeks, setWeeks] = useState(2);

--- a/src/app/professional/requests/[id]/page.tsx
+++ b/src/app/professional/requests/[id]/page.tsx
@@ -2,7 +2,8 @@
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import AvailabilityCalendar from "../../../../components/AvailabilityCalendar";
-import { TimeSlot, toUtcDateRange, resolveTimezone } from "../../../../lib/availability";
+import type { TimeSlot } from "../../../../lib/availability";
+import { toUtcDateRange, resolveTimezone } from "../../../../lib/availability";
 
 export default function RequestSchedule({ params }: { params: { id: string } }) {
   const [slots, setSlots] = useState<TimeSlot[]>([]);


### PR DESCRIPTION
## Summary
- mark DateTime and TimeSlot imports/exports as type-only to avoid runtime re-export errors
- update downstream modules to use type-only imports from the availability helper

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d28695995883258efcc64c7a1bfc5e