### PR TITLE
Remove legacy default availability fallbacks

### DIFF
--- a/src/app/(public)/signup/details/DetailsForm.tsx
+++ b/src/app/(public)/signup/details/DetailsForm.tsx
@@ -31,7 +31,7 @@ export default function DetailsForm({ initialRole }: { initialRole: 'CANDIDATE' 
   const [education, setEducation] = useState<
     { school: string; title: string; startDate: string; endDate: string }[]
   >([{ school: '', title: '', startDate: '', endDate: '' }]);
-  const [availabilityRanges, setAvailabilityRanges] = useState<AvailabilityRange[]>([]);
+  const [busyRanges, setBusyRanges] = useState<AvailabilityRange[]>([]);
   const router = useRouter();
 
   const addInterest = () => setInterests([...interests, '']);
@@ -110,7 +110,7 @@ export default function DetailsForm({ initialRole }: { initialRole: 'CANDIDATE' 
     };
     if (role === 'CANDIDATE') {
       body.resumeUrl = resumeUrl || undefined;
-      if (availabilityRanges.length > 0) body.defaultAvailability = availabilityRanges;
+      if (busyRanges.length > 0) body.defaultBusy = busyRanges;
     } else {
       body.employer = employer;
       body.title = title;
@@ -431,7 +431,7 @@ export default function DetailsForm({ initialRole }: { initialRole: 'CANDIDATE' 
       </Button>
 
       {role === 'CANDIDATE' && (
-      <AvailabilityTimes ranges={availabilityRanges} onChange={setAvailabilityRanges} />
+        <AvailabilityTimes ranges={busyRanges} onChange={setBusyRanges} />
       )}
 
       {error && <p style={{ color: 'red' }}>{error}</p>}

--- a/src/app/api/candidate/settings/route.ts
+++ b/src/app/api/candidate/settings/route.ts
@@ -28,7 +28,7 @@ async function fetchSettings(userId: string) {
     feedbackReceived: true,
     chatScheduled: true,
   };
-  const defaultAvailability = flags.defaultAvailability || flags.defaultBusy || [];
+  const defaultBusy = flags.defaultBusy || [];
   const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ');
   const timezone = user.timezone;
   return {
@@ -36,7 +36,7 @@ async function fetchSettings(userId: string) {
     email: user.email,
     resumeUrl,
     notifications,
-    defaultAvailability,
+    defaultBusy,
     timezone,
   };
 }
@@ -55,9 +55,8 @@ export async function PUT(req: Request) {
   const name = (form.get('name') as string) || '';
   const email = (form.get('email') as string) || '';
   const notifications = JSON.parse((form.get('notifications') as string) || '{}');
-  const defaultAvailabilityRaw =
-    (form.get('defaultAvailability') as string) || (form.get('defaultBusy') as string) || '[]';
-  const defaultAvailability = JSON.parse(defaultAvailabilityRaw);
+  const defaultBusyRaw = (form.get('defaultBusy') as string) || '[]';
+  const defaultBusy = JSON.parse(defaultBusyRaw);
   const timezone = (form.get('timezone') as string) || '';
   const file = form.get('resume') as File | null;
 
@@ -71,8 +70,7 @@ export async function PUT(req: Request) {
   const flags = {
     ...(existing?.flags as any || {}),
     notifications,
-    defaultAvailability,
-    defaultBusy: defaultAvailability,
+    defaultBusy,
   };
 
   await prisma.user.update({

--- a/src/app/api/onboarding/route.ts
+++ b/src/app/api/onboarding/route.ts
@@ -51,15 +51,6 @@ export async function POST(req: NextRequest) {
           }),
         )
         .min(1),
-      defaultAvailability: z
-        .array(
-          z.object({
-            day: z.number().min(0).max(6),
-            start: z.string(),
-            end: z.string(),
-          }),
-        )
-        .optional(),
       defaultBusy: z
         .array(
           z.object({
@@ -80,19 +71,16 @@ export async function POST(req: NextRequest) {
       activities,
       experience,
       education,
-      defaultAvailability,
       defaultBusy,
     } = parsed.data;
-    const availabilityDefaults = defaultAvailability || defaultBusy || [];
+    const availabilityDefaults = defaultBusy || [];
     const existing = await prisma.user.findUnique({
       where: { id: session.user.id },
       select: { flags: true },
     });
     const flags = {
       ...(existing?.flags as any || {}),
-      ...(availabilityDefaults
-        ? { defaultAvailability: availabilityDefaults, defaultBusy: availabilityDefaults }
-        : {}),
+      ...(availabilityDefaults ? { defaultBusy: availabilityDefaults } : {}),
     };
     await prisma.user.update({
       where: { id: session.user.id },

--- a/src/app/candidate/settings/AvailabilityTimes.tsx
+++ b/src/app/candidate/settings/AvailabilityTimes.tsx
@@ -28,7 +28,7 @@ export default function AvailabilityTimes({
 
   return (
     <div className="col" style={{ gap: 8 }}>
-      <h3>Default Availability</h3>
+      <h3>Default Busy Times</h3>
       {ranges.map((r, idx) => (
         <div key={idx} className="row" style={{ gap: 8, alignItems: 'center' }}>
           <select value={r.day} onChange={e => updateRange(idx, 'day', parseInt(e.target.value))}>

--- a/src/app/candidate/settings/SettingsForm.tsx
+++ b/src/app/candidate/settings/SettingsForm.tsx
@@ -22,8 +22,8 @@ export default function SettingsForm() {
   const [form, setForm] = useState<SettingsData>({ name: '', email: '', resumeUrl: null, timezone: '' });
   const [initialForm, setInitialForm] = useState<SettingsData>({ name: '', email: '', resumeUrl: null, timezone: '' });
   const [resumeFile, setResumeFile] = useState<File | null>(null);
-  const [availabilityRanges, setAvailabilityRanges] = useState<AvailabilityRange[]>([]);
-  const [initialAvailability, setInitialAvailability] = useState<AvailabilityRange[]>([]);
+  const [busyRanges, setBusyRanges] = useState<AvailabilityRange[]>([]);
+  const [initialBusyRanges, setInitialBusyRanges] = useState<AvailabilityRange[]>([]);
   const [notifications, setNotifications] = useState<Notifications>({
     feedbackReceived: true,
     chatScheduled: true,
@@ -40,9 +40,9 @@ export default function SettingsForm() {
         const data = await res.json();
         setForm({ name: data.name, email: data.email, resumeUrl: data.resumeUrl, timezone: data.timezone });
         setInitialForm({ name: data.name, email: data.email, resumeUrl: data.resumeUrl, timezone: data.timezone });
-        const defaults = data.defaultAvailability || data.defaultBusy || [];
-        setAvailabilityRanges(defaults);
-        setInitialAvailability(defaults);
+        const defaults = data.defaultBusy || [];
+        setBusyRanges(defaults);
+        setInitialBusyRanges(defaults);
         setNotifications(data.notifications || { feedbackReceived: true, chatScheduled: true });
         setInitialNotifications(data.notifications || { feedbackReceived: true, chatScheduled: true });
       }
@@ -60,16 +60,16 @@ export default function SettingsForm() {
     fd.append('email', form.email);
     fd.append('timezone', form.timezone);
     fd.append('notifications', JSON.stringify(notifications));
-    fd.append('defaultAvailability', JSON.stringify(availabilityRanges));
+    fd.append('defaultBusy', JSON.stringify(busyRanges));
     if (resumeFile) fd.append('resume', resumeFile);
     const res = await fetch('/api/candidate/settings', { method: 'PUT', body: fd });
     if (res.ok) {
       const data = await res.json();
       setForm({ name: data.name, email: data.email, resumeUrl: data.resumeUrl, timezone: data.timezone });
       setInitialForm({ name: data.name, email: data.email, resumeUrl: data.resumeUrl, timezone: data.timezone });
-      const defaults = data.defaultAvailability || data.defaultBusy || [];
-      setAvailabilityRanges(defaults);
-      setInitialAvailability(defaults);
+      const defaults = data.defaultBusy || [];
+      setBusyRanges(defaults);
+      setInitialBusyRanges(defaults);
       setNotifications(data.notifications || { feedbackReceived: true, chatScheduled: true });
       setInitialNotifications(data.notifications || { feedbackReceived: true, chatScheduled: true });
       alert('Settings saved');
@@ -80,7 +80,7 @@ export default function SettingsForm() {
 
   const handleCancel = () => {
     setForm(initialForm);
-    setAvailabilityRanges(initialAvailability);
+    setBusyRanges(initialBusyRanges);
     setNotifications(initialNotifications);
     setResumeFile(null);
   };
@@ -157,7 +157,7 @@ export default function SettingsForm() {
         </div>
       </Card>
       <Card className="col" style={{ padding: 16 }}>
-        <AvailabilityTimes ranges={availabilityRanges} onChange={setAvailabilityRanges} />
+        <AvailabilityTimes ranges={busyRanges} onChange={setBusyRanges} />
       </Card>
     </div>
   );


### PR DESCRIPTION
## Summary
- drop legacy defaultAvailability handling from candidate settings and onboarding endpoints
- rely exclusively on defaultBusy data in candidate settings UI and availability calendar

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de8f6fcb48832595623e371314d3a8