### PR TITLE
Reduce availability confirmation payload size

### DIFF
--- a/src/components/AvailabilityCalendar.tsx
+++ b/src/components/AvailabilityCalendar.tsx
@@ -14,6 +14,7 @@ import {
   formatDateInTimezone,
   startOfWeekInTimezone,
   resolveTimezone,
+  mergeSlots,
 } from '../../lib/availability';
 
 type CalendarSlot = TimeSlot & { sourceTimezone?: string };
@@ -341,6 +342,7 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({
         availableWithinRange.map(slot => toUtcDateRange(slot).start.getTime()),
       );
       const availablePayload = availableWithinRange.map(normalizeForSubmit);
+      const mergedAvailablePayload = mergeSlots(availablePayload);
 
       const uniqueBusy = new Map<number, CalendarSlot>();
       defaultBusySlots.forEach(slot => {
@@ -356,14 +358,15 @@ const AvailabilityCalendar: React.FC<AvailabilityCalendarProps> = ({
           return start < endLimit && !availableKeys.has(start.getTime());
         })
         .map(normalizeForSubmit);
+      const mergedBusyPayload = mergeSlots(busyPayload);
 
       if (onConfirm) {
-        await onConfirm(availablePayload);
+        await onConfirm(mergedAvailablePayload);
       } else {
         await fetch('/api/candidate/availability', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ events: availablePayload, busy: busyPayload }),
+          body: JSON.stringify({ events: mergedAvailablePayload, busy: mergedBusyPayload }),
         });
       }
     } else if (onConfirm && selected) {


### PR DESCRIPTION
## Summary
- merge contiguous availability and busy slots on the client before submission
- reuse the backend merge logic to keep the API payload compact when confirming availability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e17f878da08325b0bf28609e2532a1