### PR TITLE
Show generic error message in status popup

### DIFF
--- a/src/components/StatusPopup.tsx
+++ b/src/components/StatusPopup.tsx
@@ -106,7 +106,7 @@ function StatusPopup({status}:{status:StatusState | null}){
       zIndex:1000
     }}>
       {status.state === 'processing' && <div className="status-spinner" />}
-      <span>{status.message}</span>
+      <span>{status.state === 'error' ? 'Error' : status.message}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update the status popup to display a generic "Error" label when an error occurs
- prevent detailed error messages from being shown directly in the popup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e184c3583883259a1392efa5117636